### PR TITLE
V04

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,12 +4,12 @@
 
 Kotobase follows [`Semantic Versioning`](https://semver.org/)
 
-Security fixes are applied to the latest `0.3.x` release line
+Security fixes are applied to the latest `0.4.x` release line
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| `0.3.x`  | :white_check_mark: |
-| `< 0.3.0`| :x:                |
+| `0.4.x`  | :white_check_mark: |
+| `< 0.4.0`| :x:                |
 
 ## Reporting a Vulnerability
 
@@ -30,6 +30,6 @@ Please include:
 ## What to Expect
 
 - An acknowledgement within **7 days**.
-- An assessment and, where applicable, a fix targeting the next `0.3.x` patch
+- An assessment and, where applicable, a fix targeting the next `0.4.x` patch
   release.
 - Credit in the release notes if you would like to be named.

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,16 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+    patch:
+      default:
+        target: 80%
+        threshold: 5%

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,9 +1,5 @@
 name: docs
 
-# Publishes the MkDocs site to GitHub Pages on every published release
-# Requires the repository Pages source to be set to "GitHub Actions"
-# (Settings -> Pages -> Build and deployment -> Source).
-
 on:
   release:
     types: [published]

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -35,3 +35,33 @@ jobs:
 
       - name: Mypy
         run: mypy src/
+
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    defaults:
+      run:
+        working-directory: kotobase
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install Package With Dev Extras
+        run: pip install -e ".[dev]"
+
+      - name: Pytest
+        run: pytest --cov=kotobase --cov-report=xml
+
+      - name: Upload Coverage To Codecov
+        uses: codecov/codecov-action@v7
+        with:
+          files: kotobase/coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,14 +1,5 @@
 name: release
 
-# Builds the sdist and wheel and publishes them to PyPI on a published release,
-# using PyPI Trusted Publishing (OIDC, no API token). Publishing is gated on the
-# quality checks passing.
-#
-# One-time setup:
-#   - Register this repository and the `release.yaml` workflow as a trusted
-#     publisher for the `kotobase` project on PyPI.
-#   - Create a `pypi` environment in the repository settings.
-
 on:
   release:
     types: [published]
@@ -41,6 +32,10 @@ jobs:
 
       - name: Mypy
         run: mypy src/
+
+      - name: PyTest
+        run: pytest --cov=kotobase --cov-report=xml
+
 
   build:
     needs: quality

--- a/docs-site/docs/examples.md
+++ b/docs-site/docs/examples.md
@@ -18,209 +18,130 @@ kb = Kotobase()
     All returned objects are typed, immutable [`DTOs`][kotobase.db.dtos] that do not depend on an open
     session, so they are safe to keep, pass around and serialize
 
-## Comprehensive Lookup
+## Build A Flashcard Deck
 
-`lookup` Aggregates Every Source Into One Result
-
-```python
-result = kb.lookup("日本語")
-result = kb("日本語")  # (1)!
-
-for entry in result.entries:
-    print(
-        f"Written Form : {entry.headword}",
-        f"High-Frequency Word ? : {entry.is_common}"
-        )
-    for sense in entry.senses:
-        print(f"Meanings : {''.join(g.text for g in sense.glosses)}")
-
-for kanji in result.kanji:
-    print(
-        f"Literal: {kanji.literal}",
-        f"Meanings: {kanji.meanings}"
-        )
-```
-
-1. Alias For `kb.lookup`
-
-### Options
+Turn a `Tanos JLPT` level into study cards for an `SRS` app like `Anki`. Each
+card pulls the reading, meaning and frequency from the dictionary, the stroke
+order for every kanji, and a pronunciation clip, then exports as `JSON` with
+Japanese text kept verbatim
 
 ```python
-result = kb.lookup(
-    "食べ*",
-    wildcard=True, # (1)!
-    include_names=True, # (2)!
-    sentence_limit=10,  # (3)!
-    with_labels=True,  # (4)!
-)
-print(result.labels["sl"])
+import json
+from pathlib import Path
+
+from kotobase import AudioDatabaseNotFoundError, Kotobase
+
+kb = Kotobase()
+
+
+def build_deck(level: int, audio_dir: Path) -> list[dict]:
+    cards: list[dict] = []
+    for vocab in kb.jlpt_list("vocab", level):  # (1)!
+        word = vocab.word or vocab.reading
+        if not word:
+            continue
+
+        result = kb.lookup(word)  # (2)!
+        readings = kb.furigana(word)  # (3)!
+        card = {
+            "word": word,
+            "reading": vocab.reading,
+            "meaning": vocab.meaning,
+            "common": any(e.is_common for e in result.entries),  # (4)!
+            "parts_of_speech": (
+                result.entries[0].all_pos() if result.entries else []
+            ),  # (5)!
+            "furigana": readings[0].segments if readings else [],
+            "kanji": [
+                {"literal": k.literal, "stroke_order": kb.stroke_svg(k.literal)}
+                for k in result.kanji  # (6)!
+            ],
+        }
+
+        try:
+            saved = kb.save_audio(word, audio_dir)  # (7)!
+            card["audio"] = [path.name for path in saved]
+        except AudioDatabaseNotFoundError:
+            card["audio"] = []
+
+        cards.append(card)
+    return cards
+
+
+deck = build_deck(5, Path("audio"))
+Path("n5_deck.json").write_text(
+    json.dumps(deck, ensure_ascii=False, indent=2), encoding="utf-8"
+)  # (8)!
 ```
 
-1. Treat `*` As A Wildcard
-2. Include Proper Names From `JMNedict`
-3. Return 10 Example Sentences + Translations
-4. Resolve `JMDict` / `JMNedict` Tag Codes To Their Descriptions *(sl -> slang)*
+1. Every N5 vocabulary item from the `Tanos` list
+2. Enrich the word with its full dictionary entry and per-kanji details
+3. Per-form furigana segments, ready to render as ruby text
+4. A pure `DTO` field, so a deck can prioritise common words
+5. A pure `DTO` helper, the unique parts of speech across every sense
+6. A renderable stroke-order `SVG` for each kanji in the word
+7. Writes `<reading>.<fmt>` into the directory, needs the optional audio pack
+8. Import-ready, with Japanese text and any audio file names kept verbatim
 
----
+## Explore Related Words
 
-## Search Kanji
-
-Filter Kanji By Scalar Attributes, Or Look Them Up By SKIP Code
+Power a writing assistant by expanding one entry into the words around it: its
+meaning with human-readable tags, the entries its cross-references and antonyms
+point to, other vocabulary that shares a kanji, and a natural usage example
 
 ```python
-n5 = kb.search_kanji(jlpt=5, limit=50)  # (1)!
-eight_strokes = kb.search_kanji(stroke_count=8, grade=2) # (2)!
-by_skip = kb.kanji_by_skip("1-4-3") # (3)!
+import pprint
+
+from kotobase import Kotobase
+
+kb = Kotobase()
+
+
+def related_words(word: str) -> dict:
+    result = kb.lookup(word, with_labels=True)  # (1)!
+    if not result.entries:
+        return {}
+
+    entry = result.entries[0]
+    sense = entry.senses[0]
+    panel = {
+        "word": entry.headword,
+        "meaning": [gloss.text for gloss in sense.glosses],
+        "tags": sense.expand_tags(result.labels),  # (2)!
+        "see_also": [e.headword for e in kb.resolve_references(entry)],  # (3)!
+    }
+
+    if entry.kanji:
+        kanji = entry.kanji[0].text[0]
+        panel["shares_kanji"] = [
+            e.headword
+            for e in kb.words_with_kanji(kanji, limit=8)  # (4)!
+            if e.headword != entry.headword
+        ]
+        panel["example"] = next(
+            (s.text for s in kb.sentences_with_kanji(kanji, limit=1)), None
+        )  # (5)!
+
+    return panel
+
+
+pprint.pp(related_words("勉強"))
 ```
 
-1. First 50 Kanji Listed In `Tanos' N5 JLPT List`
-2. Only Kanji That Have 8 Strokes And Are Learned In The Second Grade
-3. Kanji That Are Vertically Split Into Left / Right Parts `(1-)`, Where The Left Part Has 4 Strokes `(1-4)`, And The Right Part Has 3 Strokes `(1-4-3)` *(e.g 那)*. Read More About The [`System of Kanji Indexing by Patterns`](https://www.edrdg.org/wwwjdic/SKIP.html)
+1. `with_labels` fills `result.labels` with each tag code's description
+2. Resolve this sense's tag codes to descriptions on the `DTO` itself
+3. Follow the entry's cross-references and antonyms to the real entries
+4. Other words written with the kanji, accepts a string or a `KanjiDTO`
+5. A natural sentence using the kanji, `None` when nothing matches
+
+???+ tip "Async Applications"
+    The read layer is `thread-safe`, so a web app can run any lookup off the
+    event loop without blocking it
+
+    ```python
+    import asyncio
 
 
-## Radicals
-
-Find Kanji Which Contain Certain `Radicals`
-
-```python
-radicals = kb.radicals()  # (1)!
-matches = kb.by_radicals(["言", "五"]) #  (2)!
-```
-
-1. View Every Search Radical
-2. Find All Kanji That Contain Both `言` + `五` Radicals *(e.g 語)*
-
-## Proper Names
-
-```python
-tanaka = kb.names("田中")  # (1)!
-places = kb.names(name_type="place")  #(2)!
-```
-
-1. Search A Proper Name Entry
-2. Search By Name Type
-
-## Search By Meaning
-
-Find Entries From Their English Gloss Using Full Text Search
-
-```python
-for entry in kb.search_meaning("to eat", limit=10):
-    print(entry.headword)
-```
-
-## Example Sentences
-
-Find Example Sentences Containing A Given Text
-
-```python
-for sentence in kb.sentences("日本", limit=5):
-    print(sentence.text)
-    for translation in sentence.translations:
-        print("  ", translation)
-```
-
-## Furigana
-
-View Furigana Segmentation For A Given Word
-
-```python
-for item in kb.furigana("食べる"):
-    print(item.reading, item.segments)
-```
-
-## JLPT
-
-Browse `Tanos JLPT` Study Lists
-
-```python
-level = kb.jlpt_level("勉強")
-
-vocab = kb.jlpt_list("vocab", 5)
-kanji = kb.jlpt_list("kanji", 5)
-grammar = kb.jlpt_list("grammar", 2)
-```
-
-## Stroke Order
-
-Access Stroke Order SVGs
-
-```python
-svg = kb.stroke_svg("春") # (1)!
-raw = kb.stroke_svg("春", raw=True) # (2)!
-if svg is not None:
-    open("haru.svg", "w", encoding="utf-8").write(svg)
-```
-
-1. A Renderable `SVG` Document
-2. The Raw `KanjiVG` fragment
-
-## Audio
-
-Access Pronunciation Audio From The Optional Audio Pack
-
-```python
-clips = kb.audio("語")  # (1)!
-for clip in clips:
-    print(clip.reading, clip.fmt, clip.source, clip.license)
-
-files = kb.audio_bytes("語")  # (2)!
-name, data = files[0]
-
-paths = kb.save_audio("語", "clips")  # (3)!
-```
-
-1. Clip Metadata, Without The Bytes
-2. Each Clip As A `(file_name, bytes)` Pair
-3. Write Every Clip Into `clips/` And Return The Written Paths
-
-???+ warning "Needs The Audio Pack"
-    These Raise `AudioDatabaseNotFoundError` When The Optional Audio Pack Is Not Installed *(`kotobase db pull --with-audio`)*
-
-
-
-## Expanding Tag Codes
-
-Exapand `JMDict` / `JMNedict` Tag Codes To Their Full Descriptions
-
-```python
-labels = kb.expand_tags(["sl", "n", "vs"])
-# {"sl": "slang", "n": "noun (common) (futsuumeishi)", ...}
-```
-
-## Serialization
-
-Every Result Object Can Be Turned Into A Plain Dictionary Or JSON With
-Japanese Text Kept Verbatim
-
-```python
-result = kb.lookup("語")
-data = result.to_dict()
-text = result.to_json()
-for field, value in result:   # iteration yields (field, value) pairs
-    ...
-```
-
-## Database Metadata
-
-```python
-info = kb.db_info()
-print(info["build_date"], info["size_mb"])
-```
-
-## Using Kotobase Concurrently
-
-The Read Layer Is `Thread-Safe`, So An `async` Application Can Run A `lookup` Off
-The Event Loop Without Blocking It
-
-```python
-import asyncio
-
-
-async def main() -> None:
-    result = await asyncio.to_thread(kb.lookup, "日本語")
-    print(result.query)
-
-
-asyncio.run(main())
-```
+    async def lookup(word: str):
+        return await asyncio.to_thread(kb.lookup, word)
+    ```

--- a/docs-site/docs/project/changelog.md
+++ b/docs-site/docs/project/changelog.md
@@ -5,6 +5,63 @@ All notable changes to this project are documented here
 The format is based on [`Keep a Changelog`](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [`Semantic Versioning`](versioning.md)
 
+## [`0.4.0`](https://github.com/svdC1/kotobase/releases/tag/v0.4.0) - 2026-07-01
+
+Richer data objects, a typed exception hierarchy, and a fix for the audio pull
+
+### Breaking Changes
+
+- `JSON Output Shape` &rarr; The CLI `--json` output now follows `Pydantic`'s
+  `model_dump_json`. Field names are unchanged and Japanese text stays verbatim,
+  but the exact shape may differ from `0.3.0`, which `0.x` SemVer allows
+
+- `DTO Serialization` &rarr; The `Serializable` mixin and its `to_dict` /
+  `to_json` helpers are removed, serialize the `Pydantic` `DTOs` with
+  `model_dump` / `model_dump_json` instead
+
+- `Bad-Argument Errors` &rarr; The `API` now raises `APIError` from the new
+  hierarchy on invalid arguments instead of `ValueError`
+
+### Added
+
+- `Data-Facing DTO Methods` &rarr; The data objects gained pure helpers such as
+  `JMDictEntryDTO.all_pos` / `common_kanji`, `SenseDTO.all_tags` /
+  `expand_tags`, `KanjiDTO.skip_codes` / `is_joyo`, and `LookupResult.has_*`
+
+- `Exception Hierarchy` &rarr; A new
+  [`kotobase.exceptions`][kotobase.exceptions] module rooted at `KotobaseError`
+  *(`DatabaseError`, `SourceExtractionError`, `DownloadError`, `APIError` and
+  their leaves)*, re-exported from the top-level package
+
+- `New API Methods` &rarr; `words_with_kanji`, `sentences_with_kanji` and
+  `resolve_references` *(each accepting a `DTO` or a string)*, plus a `match`
+  argument on `by_radicals` to find kanji containing any of a set of radicals
+  as well as all of them
+
+- `DTO Arguments` &rarr; The key-taking methods now accept a `DTO` as well as a
+  string, reading the lookup key off the object, so a result from one call can
+  be passed straight into another *(e.g. `sentences(entry)`, `stroke_svg(kanji)`)*
+
+- `Test Suite` &rarr; A `pytest` suite run against a tiny fixture database, with
+  coverage reported to `Codecov` across `Python` 3.10 to 3.13
+
+### Changed
+
+- `Pydantic DTOs` &rarr; The data objects are now `Pydantic` models that carry
+  data-facing behaviour and are built with `model_validate` straight from the
+  `ORM` rows
+
+- `Typed Errors` &rarr; Repositories wrap unexpected database failures as
+  `DatabaseError`, and the build pipeline raises `DownloadError` /
+  `SourceExtractionError`. The `CLI` renders any `KotobaseError` as a friendly
+  message instead of a traceback
+
+### Fixed
+
+- `Audio Pull` &rarr; `kotobase db pull` previously rebuilt the audio database
+  locally from the `Kanji Alive` sources instead of pulling the pre-built
+  `kotobase-audio.db.zst` release asset
+
 ## [`0.3.0`](https://github.com/svdC1/kotobase/releases/tag/v0.3.0) - 2026-06-26
 
 A full rewrite of the package, its data and its tooling

--- a/docs-site/docs/project/versioning.md
+++ b/docs-site/docs/project/versioning.md
@@ -32,9 +32,8 @@ top-level `kotobase` package and the documented command line
     - `kotobase.__version__`
     - The [`Kotobase`][kotobase.api.Kotobase] class and its documented methods
     - All [`DTOs`][kotobase.db.dtos]
-    - The [`DatabaseNotFoundError`][kotobase.db.connection.DatabaseNotFoundError]
-      and [`AudioDatabaseNotFoundError`][kotobase.db.connection.AudioDatabaseNotFoundError]
-      exceptions
+    - The [`exception hierarchy`][kotobase.exceptions] rooted at `KotobaseError`,
+      re-exported from the top-level package
     - All `kotobase` CLI command names and their documented options
 
 ## What Is Not Public
@@ -50,7 +49,7 @@ top-level `kotobase` package and the documented command line
     - [`connection`][kotobase.db.connection]
     - [`builder`][kotobase.db.builder]
     - [`terminal_output`][kotobase.terminal_output]
-    - The exact `CLI` output formatting and wording *(Only the `--json` shape + the commands and options are stable)*
+    - The exact `CLI` output formatting and wording. The `--json` keys mirror the public `DTO` fields and keep Japanese text verbatim, but the exact serialization shape may change between `0.x` minor releases
     - The on-disk database file layout and any raw build artifacts
 
 ## Database Schema

--- a/docs-site/docs/reference/exceptions.md
+++ b/docs-site/docs/reference/exceptions.md
@@ -1,0 +1,1 @@
+:::kotobase.exceptions

--- a/kotobase/pyproject.toml
+++ b/kotobase/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kotobase"
-version = "0.3.0"
+version = "0.4.0"
 authors = [{ name = "svdc", email = "svdc1mail@gmail.com" }]
 maintainers = [{ name = "svdc", email = "svdc1mail@gmail.com" }]
 description = "A comprehensive, openly-licensed Japanese language database"
@@ -36,6 +36,7 @@ classifiers = [
 ]
 dependencies = [
     "sqlalchemy>=2.0",
+    "pydantic>=2.0",
     "typer>=0.12",
     "rich>=13.0",
     "requests>=2.31",
@@ -68,7 +69,7 @@ dev = [
 ]
 
 [project.scripts]
-kotobase = "kotobase.cli:app"
+kotobase = "kotobase.cli:main"
 
 [project.urls]
 Homepage = "https://github.com/svdC1/kotobase"

--- a/kotobase/src/kotobase/__init__.py
+++ b/kotobase/src/kotobase/__init__.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 from importlib.metadata import PackageNotFoundError, version
 
 from .api import Kotobase
-from .db.connection import AudioDatabaseNotFoundError, DatabaseNotFoundError
 from .db.dtos import (
     AudioDTO,
     FuriganaDTO,
@@ -35,7 +34,17 @@ from .db.dtos import (
     RadicalDTO,
     SenseDTO,
     SentenceDTO,
-    Serializable,
+)
+from .exceptions import (
+    APIError,
+    AudioDatabaseNotFoundError,
+    DatabaseError,
+    DatabaseExistsError,
+    DatabaseNotFoundError,
+    DownloadError,
+    KotobaseError,
+    MalformedSourceError,
+    SourceExtractionError,
 )
 
 try:
@@ -44,9 +53,13 @@ except PackageNotFoundError:
     __version__ = "0.0.0"
 
 __all__ = [
+    "APIError",
     "AudioDTO",
     "AudioDatabaseNotFoundError",
+    "DatabaseError",
+    "DatabaseExistsError",
     "DatabaseNotFoundError",
+    "DownloadError",
     "FuriganaDTO",
     "GlossDTO",
     "JLPTGrammarDTO",
@@ -58,11 +71,13 @@ __all__ = [
     "KanjiDTO",
     "KanjiFormDTO",
     "Kotobase",
+    "KotobaseError",
     "LookupResult",
+    "MalformedSourceError",
     "NameTranslationDTO",
     "RadicalDTO",
     "SenseDTO",
     "SentenceDTO",
-    "Serializable",
+    "SourceExtractionError",
     "__version__",
 ]

--- a/kotobase/src/kotobase/api.py
+++ b/kotobase/src/kotobase/api.py
@@ -14,6 +14,7 @@ simple and correct for read-only `SQLite`
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
 
 from sqlalchemy import text
@@ -26,12 +27,17 @@ from .db.dtos import (
     JLPTVocabDTO,
     JMDictEntryDTO,
     JMNeDictEntryDTO,
+    KanaFormDTO,
     KanjiDTO,
+    KanjiFormDTO,
+    Keyed,
     LookupResult,
     RadicalDTO,
+    SenseDTO,
     SentenceDTO,
 )
 from .db.uow import UnitOfWork
+from .exceptions import APIError
 
 _JLPT_LIST_METHODS = {
     "vocab": "list_vocab",
@@ -83,6 +89,24 @@ def _collect_codes(
     return list(codes)
 
 
+def _key(value: str | Keyed) -> str:
+    """
+    Coerce a lookup key, or a DTO that carries one, to its key string
+
+    A plain string passes through unchanged. Any DTO satisfying
+    [`Keyed`][kotobase.db.dtos.Keyed] returns its own `key`, so a result from
+    one call can be passed straight into another method without unpacking a
+    field by hand
+
+    Args:
+        value (str | Keyed): A key string, or a DTO that carries a lookup key
+
+    Returns:
+        The lookup key as a string
+    """
+    return value if isinstance(value, str) else value.key
+
+
 class Kotobase:
     """
     Stateless entry point for querying the kotobase database
@@ -94,7 +118,7 @@ class Kotobase:
         *,
         wildcard: bool = False,
         include_names: bool = False,
-        sentence_limit: int = 50,
+        sentence_limit: int | None = 50,
         entry_limit: int | None = None,
         with_labels: bool = False,
     ) -> LookupResult:
@@ -106,7 +130,8 @@ class Kotobase:
                 act as wildcards when `wildcard` is True
             wildcard (bool): When True, match forms as a `LIKE` pattern
             include_names (bool): When True, also search JMnedict proper names
-            sentence_limit (int): Maximum number of example sentences to return
+            sentence_limit (int | None): Maximum number of example
+                sentences to return
             entry_limit (int | None): Maximum number of dictionary entries to
                 return, or None for no limit
             with_labels (bool): When True, resolve every tag code in the result
@@ -177,18 +202,22 @@ class Kotobase:
             labels=labels,
         )
 
-    def kanji(self, literal: str) -> KanjiDTO | None:
+    def kanji(
+        self,
+        literal: str | KanjiDTO | KanjiFormDTO,
+    ) -> KanjiDTO | None:
         """
         Return the full profile of a single kanji
 
         Args:
-            literal (str): The kanji literal
+            literal (str | KanjiDTO | KanjiFormDTO): The kanji, as a character
+                or a DTO to read it from
 
         Returns:
             The kanji details, or None when it is not in the database
         """
         with UnitOfWork() as uow:
-            return uow.kanji.by_literal(literal)
+            return uow.kanji.by_literal(_key(literal))
 
     def search_kanji(
         self,
@@ -197,7 +226,7 @@ class Kotobase:
         grade: int | None = None,
         freq_max: int | None = None,
         jlpt: int | None = None,
-        limit: int = 100,
+        limit: int | None = 100,
     ) -> list[KanjiDTO]:
         """
         Search kanji by its scalar attributes
@@ -207,7 +236,7 @@ class Kotobase:
             grade (int | None): Required school grade
             freq_max (int | None): Maximum newspaper frequency rank
             jlpt (int | None): Required Tanos JLPT level
-            limit (int): Maximum number of kanji to return
+            limit (int | None): Maximum number of kanji to return
 
         Returns:
             The matching kanji ordered by frequency then character
@@ -221,13 +250,18 @@ class Kotobase:
                 limit=limit,
             )
 
-    def kanji_by_skip(self, code: str, *, limit: int = 100) -> list[KanjiDTO]:
+    def kanji_by_skip(
+        self,
+        code: str,
+        *,
+        limit: int | None = 100,
+    ) -> list[KanjiDTO]:
         """
         Find kanji with a given `SKIP` query code
 
         Args:
             code (str): The SKIP code such as `1-4-3`
-            limit (int): Maximum number of kanji to return
+            limit (int | None): Maximum number of kanji to return
 
         Returns:
             The matching kanji as data transfer objects
@@ -235,7 +269,12 @@ class Kotobase:
         with UnitOfWork() as uow:
             return uow.kanji.by_skip(code, limit=limit)
 
-    def stroke_svg(self, literal: str, *, raw: bool = False) -> str | None:
+    def stroke_svg(
+        self,
+        literal: str | KanjiDTO,
+        *,
+        raw: bool = False,
+    ) -> str | None:
         """
         Return a kanji's stroke order as SVG
 
@@ -244,14 +283,14 @@ class Kotobase:
         instead, which has no `<svg>` root or styling
 
         Args:
-            literal (str): The kanji character
+            literal (str | KanjiDTO): The kanji string or a `KanjiDTO` object
             raw (bool): When True, return the raw KanjiVG fragment unwrapped
 
         Returns:
             The stroke order SVG, or None when not available
         """
         with UnitOfWork() as uow:
-            return uow.kanji.stroke_svg(literal, raw=raw)
+            return uow.kanji.stroke_svg(_key(literal), raw=raw)
 
     def radicals(self) -> list[RadicalDTO]:
         """
@@ -263,32 +302,50 @@ class Kotobase:
         with UnitOfWork() as uow:
             return uow.radicals.list_radicals()
 
-    def by_radicals(self, radicals: list[str]) -> list[KanjiDTO]:
+    def by_radicals(
+        self,
+        radicals: Sequence[str | RadicalDTO],
+        *,
+        match: str = "all",
+    ) -> list[KanjiDTO]:
         """
-        Return the kanji that contains every one of the given radicals
+        Return the kanji that contain the given radicals
 
         Args:
-            radicals (list[str]): The radical components to require
+            radicals (list[str | RadicalDTO]): The radical components to match,
+                given as characters or RadicalDTO objects
+            match (str): `all` to require every radical (intersection), or
+                `any` to match kanji that contain at least one (union)
 
         Returns:
             The full details of each matching kanji
+
+        Raises:
+            APIError: If `match` is not `all` or `any`
         """
+        if match not in ("all", "any"):
+            raise APIError("Match Must Be 'all' Or 'any'")
+        chars = [_key(radical) for radical in radicals]
         with UnitOfWork() as uow:
-            literals = uow.radicals.kanji_by_radicals(radicals)
+            literals = uow.radicals.kanji_by_radicals(chars, match=match)
             return uow.kanji.bulk_fetch(literals)
 
-    def jlpt_level(self, word: str) -> int | None:
+    def jlpt_level(
+        self,
+        word: str | JMDictEntryDTO | JLPTVocabDTO,
+    ) -> int | None:
         """
         Return the `JLPT` vocabulary level of a word
 
         Args:
-            word (str): The word to look up
+            word (str | JMDictEntryDTO | JLPTVocabDTO): The word, as text or a
+                DTO to read it from
 
         Returns:
             The JLPT level from 1 to 5, or None when the word is not listed
         """
         with UnitOfWork() as uow:
-            vocab = uow.jlpt.vocab_by_word(word)
+            vocab = uow.jlpt.vocab_by_word(_key(word))
         return vocab.level if vocab else None
 
     def jlpt_list(
@@ -307,10 +364,13 @@ class Kotobase:
             Every item of the requested kind at the level
 
         Raises:
-            ValueError: If `kind` is not a known JLPT list kind
+            APIError: If `kind` is not a known JLPT list kind or `level` is
+                not between 1 and 5
         """
         if kind not in _JLPT_LIST_METHODS:
-            raise ValueError(f"unknown JLPT kind: {kind!r}")
+            raise APIError(f"Unknown JLPT Kind : {kind!r}")
+        if level not in range(1, 6):
+            raise APIError(f"JLPT Level Must Be 1 To 5, Got {level!r}")
         with UnitOfWork() as uow:
             if kind == "vocab":
                 return uow.jlpt.list_vocab(level)
@@ -320,20 +380,21 @@ class Kotobase:
 
     def names(
         self,
-        form: str | None = None,
+        form: str | JMNeDictEntryDTO | None = None,
         *,
         name_type: str | None = None,
         wildcard: bool = False,
-        limit: int = 50,
+        limit: int | None = 50,
     ) -> list[JMNeDictEntryDTO]:
         """
         Look up or browse `JMnedict` proper names
 
         Args:
-            form (str | None): A written or reading form to search for
+            form (str | JMNeDictEntryDTO | None): A written or reading form to
+                search for, as text or a name DTO to read it from
             name_type (str | None): A name type to browse, such as `place`
             wildcard (bool): When True, match the form as a `LIKE` pattern
-            limit (int): Maximum number of names to return
+            limit (int | None): Maximum number of names to return
 
         Returns:
             The matching names, empty when neither a form nor a type is given
@@ -343,7 +404,7 @@ class Kotobase:
                 return uow.jmnedict.browse_by_type(name_type, limit=limit)
             if form is not None:
                 return uow.jmnedict.search(
-                    form,
+                    _key(form),
                     wildcard=wildcard,
                     limit=limit,
                 )
@@ -351,44 +412,123 @@ class Kotobase:
 
     def sentences(
         self,
-        text_value: str,
+        text_value: str | JMDictEntryDTO,
         *,
-        limit: int = 20,
+        limit: int | None = 20,
     ) -> list[SentenceDTO]:
         """
         Return `Tatoeba` Japanese example sentences containing the given text
 
         Args:
-            text_value (str): The text to search for
-            limit (int): Maximum number of sentences to return
+            text_value (str | JMDictEntryDTO): The text to search for, as a
+                string or a dictionary entry to read its headword from
+            limit (int | None): Maximum number of sentences to return
 
         Returns:
             The matching example sentences
         """
         with UnitOfWork() as uow:
-            return uow.sentences.search_containing(text_value, limit=limit)
+            return uow.sentences.search_containing(
+                _key(text_value), limit=limit
+            )
+
+    def words_with_kanji(
+        self,
+        kanji: str | KanjiDTO,
+        *,
+        limit: int | None = 50,
+    ) -> list[JMDictEntryDTO]:
+        """
+        Return dictionary entries whose written form uses a kanji
+
+        Args:
+            kanji (str | KanjiDTO): The kanji character, or a KanjiDTO to read
+                the character from
+            limit (int | None): Maximum entries to return, or None for no limit
+
+        Returns:
+            The entries that use the kanji in a written form
+        """
+        literal = _key(kanji)
+        with UnitOfWork() as uow:
+            return uow.jmdict.search_form(
+                f"*{literal}*", wildcard=True, limit=limit
+            )
+
+    def sentences_with_kanji(
+        self,
+        kanji: str | KanjiDTO,
+        *,
+        limit: int | None = 20,
+    ) -> list[SentenceDTO]:
+        """
+        Return example sentences that contain a kanji
+
+        Args:
+            kanji (str | KanjiDTO): The kanji character, or a KanjiDTO to read
+                the character from
+            limit (int | None): Maximum number of sentences to return
+
+        Returns:
+            The matching example sentences with their translations
+        """
+        literal = _key(kanji)
+        with UnitOfWork() as uow:
+            return uow.sentences.search_containing(literal, limit=limit)
+
+    def resolve_references(
+        self,
+        source: JMDictEntryDTO | SenseDTO | str,
+    ) -> list[JMDictEntryDTO]:
+        """
+        Resolve the cross-references and antonyms of a sense or entry
+
+        Args:
+            source (JMDictEntryDTO | SenseDTO | str): The entry or sense whose
+                xref and antonym codes to resolve, or a single reference code
+
+        Returns:
+            The referenced entries, de-duplicated by sequence number
+        """
+        if isinstance(source, str):
+            codes = [source]
+        elif isinstance(source, SenseDTO):
+            codes = [*source.xref, *source.antonym]
+        else:
+            codes = [
+                code
+                for sense in source.senses
+                for code in (*sense.xref, *sense.antonym)
+            ]
+        seen: dict[int, JMDictEntryDTO] = {}
+        with UnitOfWork() as uow:
+            for code in codes:
+                for entry in uow.jmdict.resolve_reference(code):
+                    seen.setdefault(entry.id, entry)
+        return list(seen.values())
 
     def furigana(
         self,
-        word: str,
+        word: str | JMDictEntryDTO | KanjiFormDTO | KanaFormDTO,
         reading: str | None = None,
     ) -> list[FuriganaDTO]:
         """
         Return furigana segmentation for a written form
 
         Args:
-            word (str): The written spelling to look up
+            word (str | JMDictEntryDTO | KanjiFormDTO | KanaFormDTO): The
+                written spelling, as text or a DTO to read it from
             reading (str | None): A specific reading to narrow the match
 
         Returns:
             The matching furigana segmentations
         """
         with UnitOfWork() as uow:
-            return uow.furigana.for_text(word, reading)
+            return uow.furigana.for_text(_key(word), reading)
 
     def audio(
         self,
-        key: str,
+        key: str | KanjiDTO | JMDictEntryDTO,
         *,
         kind: str | None = None,
     ) -> list[AudioDTO]:
@@ -396,7 +536,8 @@ class Kotobase:
         Return pronunciation audio metadata for a lookup key
 
         Args:
-            key (str): The lookup key, such as a kanji or word
+            key (str | KanjiDTO | JMDictEntryDTO): The lookup key, such as a
+                kanji or word, as a string or a DTO to read it from
             kind (str | None): Restrict to a clip kind when given
 
         Returns:
@@ -407,11 +548,11 @@ class Kotobase:
                 installed
         """
         with UnitOfWork() as uow:
-            return uow.audio.for_key(key, kind=kind)
+            return uow.audio.for_key(_key(key), kind=kind)
 
     def audio_bytes(
         self,
-        key: str,
+        key: str | KanjiDTO | JMDictEntryDTO,
         *,
         reading: str | None = None,
         kind: str | None = None,
@@ -420,7 +561,8 @@ class Kotobase:
         Return the file name and raw bytes of each matching audio clip
 
         Args:
-            key (str): The lookup key, such as a kanji or word
+            key (str | KanjiDTO | JMDictEntryDTO): The lookup key, such as a
+                kanji or word, as a string or a DTO to read it from
             reading (str | None): Select a specific clip by its reading, or
                 None to return every matching clip
             kind (str | None): Restrict to a clip kind when given
@@ -434,12 +576,14 @@ class Kotobase:
                 installed
         """
         with UnitOfWork() as uow:
-            payloads = uow.audio.payloads(key, reading=reading, kind=kind)
+            payloads = uow.audio.payloads(
+                _key(key), reading=reading, kind=kind
+            )
         return payloads
 
     def save_audio(
         self,
-        key: str,
+        key: str | KanjiDTO | JMDictEntryDTO,
         dest: str | Path,
         *,
         reading: str | None = None,
@@ -449,7 +593,8 @@ class Kotobase:
         Save the matching pronunciation audio clips into a directory
 
         Args:
-            key (str): The lookup key, such as a kanji or word
+            key (str | KanjiDTO | JMDictEntryDTO): The lookup key, such as a
+                kanji or word, as a string or a DTO to read it from
             dest (str | Path): The directory to write the clips into, created
                 when it does not exist
             reading (str | None): Save only the clip with this reading when
@@ -464,7 +609,9 @@ class Kotobase:
                 installed
         """
         with UnitOfWork() as uow:
-            payloads = uow.audio.payloads(key, reading=reading, kind=kind)
+            payloads = uow.audio.payloads(
+                _key(key), reading=reading, kind=kind
+            )
         if not payloads:
             return []
         directory = Path(dest)
@@ -480,14 +627,14 @@ class Kotobase:
         self,
         query: str,
         *,
-        limit: int = 50,
+        limit: int | None = 50,
     ) -> list[JMDictEntryDTO]:
         """
         Return entries whose English meaning matches the query
 
         Args:
             query (str): The full text search expression to run against glosses
-            limit (int): Maximum number of entries to return
+            limit (int | None): Maximum number of entries to return
 
         Returns:
             The matching dictionary entries
@@ -531,7 +678,7 @@ class Kotobase:
         *,
         wildcard: bool = False,
         include_names: bool = False,
-        sentence_limit: int = 50,
+        sentence_limit: int | None = 50,
         entry_limit: int | None = None,
         with_labels: bool = False,
     ) -> LookupResult:
@@ -543,7 +690,8 @@ class Kotobase:
             query (str): The query, written in kana or kanji
             wildcard (bool): When True, match forms as a `LIKE` pattern
             include_names (bool): When True, also search JMnedict proper names
-            sentence_limit (int): Maximum number of example sentences to return
+            sentence_limit (int | None): Maximum number of example
+                sentences to return
             entry_limit (int | None): Maximum number of dictionary entries to
                 return, or None for no limit
             with_labels (bool): When True, resolve tag codes to descriptions

--- a/kotobase/src/kotobase/cli.py
+++ b/kotobase/src/kotobase/cli.py
@@ -15,22 +15,28 @@ info: Command Groups
 
 from __future__ import annotations
 
-import functools
 import io
 import json
 import shutil
 import sys
-from collections.abc import Callable
 from pathlib import Path
-from typing import Annotated, Any, ParamSpec, TypeVar
+from typing import Annotated, Any
 
 import typer
+from pydantic import BaseModel
 
 from . import __version__
 from . import terminal_output as out
 from .api import Kotobase
 from .db import builder
-from .db.connection import AudioDatabaseNotFoundError, DatabaseNotFoundError
+from .exceptions import (
+    AudioDatabaseNotFoundError,
+    DatabaseExistsError,
+    DatabaseNotFoundError,
+    DownloadError,
+    KotobaseError,
+    SourceExtractionError,
+)
 from .terminal_output import THEMED_CONSOLE
 
 # --- App Definition ---
@@ -79,48 +85,11 @@ Shared [`Kotobase`][kotobase.api.Kotobase] instance which executes query
 commands
 """
 
-_P = ParamSpec("_P")
-_R = TypeVar("_R")
-
-
-def _guard_no_db(func: Callable[_P, _R]) -> Callable[_P, _R]:
-    """
-    CLI command decorator which displays a user-friendly error message and
-    raises `typer.Exit` when the `kotobase.db` file doesn't exist in the cache
-    directory
-
-    Args:
-        func (Callable[_P, _R]): The CLI command to wrap
-
-    Returns:
-        The wrapped command function with all its metadata preserved
-    """
-
-    @functools.wraps(func)
-    def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
-        try:
-            return func(*args, **kwargs)
-        except DatabaseNotFoundError as e:
-            db = (
-                "Audio"
-                if isinstance(e, AudioDatabaseNotFoundError)
-                else "Core"
-            )
-
-            THEMED_CONSOLE.print(
-                f"[danger]⊗ Couldn't Find The {db} Database -> Run [/]"
-                f"[heading]kotobase db pull[/][danger] Or "
-                f"[/][heading]kotobase db build[/]"
-            )
-            raise typer.Exit(code=1) from None
-
-    return wrapper
-
 
 def _to_json(obj: Any) -> str:
     """
-    Serialize a result object, or a list of them, to `JSON` text preserving
-    non-ascii characters using `json.dumps`
+    Serialize a result object, or a list of them, to `JSON` text keeping
+    non-ascii characters verbatim
 
     Args:
         obj (Any): A data transfer object, a list of them, or a plain value
@@ -128,15 +97,18 @@ def _to_json(obj: Any) -> str:
     Returns:
         The object encoded as a `JSON` string
     """
+    if isinstance(obj, BaseModel):
+        return obj.model_dump_json()
     if isinstance(obj, list):
         return json.dumps(
-            [o.to_dict() if hasattr(o, "to_dict") else o for o in obj],
+            [
+                item.model_dump(mode="json")
+                if isinstance(item, BaseModel)
+                else item
+                for item in obj
+            ],
             ensure_ascii=False,
         )
-
-    if hasattr(obj, "to_json"):
-        return str(obj.to_json())
-
     return json.dumps(obj, ensure_ascii=False)
 
 
@@ -206,7 +178,6 @@ def version() -> None:
 
 
 @lookup_app.command(name="all")
-@_guard_no_db
 def lookup_all(
     query: Annotated[
         str,
@@ -273,7 +244,6 @@ def lookup_all(
 
 
 @lookup_app.command(name="kanji")
-@_guard_no_db
 def lookup_kanji(
     literal: Annotated[
         str,
@@ -305,7 +275,6 @@ def lookup_kanji(
 
 
 @lookup_app.command(name="jlpt")
-@_guard_no_db
 def lookup_jlpt(
     word: Annotated[
         str,
@@ -322,7 +291,6 @@ def lookup_jlpt(
 
 
 @lookup_app.command(name="kanji-find")
-@_guard_no_db
 def lookup_find_kanji(
     stroke: Annotated[
         int | None,
@@ -403,7 +371,6 @@ def lookup_find_kanji(
 
 
 @lookup_app.command(name="radicals")
-@_guard_no_db
 def lookup_radicals(
     components: Annotated[
         list[str] | None,
@@ -438,7 +405,6 @@ def lookup_radicals(
 
 
 @lookup_app.command(name="jlpt-list")
-@_guard_no_db
 def lookup_jlpt_list(
     kind: Annotated[
         str,
@@ -481,7 +447,6 @@ def lookup_jlpt_list(
 
 
 @lookup_app.command(name="names")
-@_guard_no_db
 def lookup_names(
     form: Annotated[
         str | None,
@@ -517,7 +482,6 @@ def lookup_names(
 
 
 @lookup_app.command(name="meaning")
-@_guard_no_db
 def lookup_meaning(
     query: Annotated[
         str,
@@ -554,7 +518,6 @@ def lookup_meaning(
 
 
 @lookup_app.command(name="sentences")
-@_guard_no_db
 def lookup_sentences(
     text_value: Annotated[
         str,
@@ -590,7 +553,6 @@ def lookup_sentences(
 
 
 @lookup_app.command(name="furigana")
-@_guard_no_db
 def lookup_furigana(
     word: Annotated[
         str,
@@ -619,7 +581,6 @@ def lookup_furigana(
 
 
 @lookup_app.command(name="kanji-svg")
-@_guard_no_db
 def lookup_kanji_svg(
     literal: Annotated[
         str,
@@ -647,7 +608,6 @@ def lookup_kanji_svg(
 
 
 @lookup_app.command(name="audio")
-@_guard_no_db
 def lookup_audio(
     key: Annotated[
         str,
@@ -693,7 +653,6 @@ def lookup_audio(
 
 
 @db_app.command(name="info")
-@_guard_no_db
 def db_info() -> None:
     """
     Show Build Metadata For The Active Database
@@ -734,26 +693,9 @@ def db_build(
     """
     Download Upstream Sources And Build The Database Locally
     """
-    try:
-        builder.build_core(
-            force=force,
-            include_links=with_links,
-        )
-    except FileExistsError:
-        THEMED_CONSOLE.print(
-            "[danger]⊗ Database Already Exists -> Run[/][heading]"
-            "kotobase db build --force[/][danger] To Rebuild[/]"
-        )
-        raise typer.Exit(1) from None
+    builder.build_core(force=force, include_links=with_links)
     if with_audio:
-        try:
-            builder.build_audio(force=force)
-        except FileExistsError:
-            THEMED_CONSOLE.print(
-                "[danger]⊗ Audio Database Already Exists -> Run[/][heading]"
-                "kotobase db build --force[/][danger] To Rebuild[/]"
-            )
-            raise typer.Exit(1) from None
+        builder.build_audio(force=force)
 
 
 @db_app.command(name="pull")
@@ -785,23 +727,9 @@ def db_pull(
     """
     Download a Pre-Built Database From A GitHub Release
     """
-    try:
-        builder.pull_db(tag=tag, force=force)
-    except FileExistsError:
-        THEMED_CONSOLE.print(
-            "[danger]⊗ Database Already Exists -> Run[/][heading]"
-            "kotobase db pull --force[/][danger] To Replace[/]"
-        )
-        raise typer.Exit(1) from None
+    builder.pull_db(tag=tag, force=force)
     if with_audio:
-        try:
-            builder.build_audio(force=force)
-        except FileExistsError:
-            THEMED_CONSOLE.print(
-                "[danger]⊗ Audio Database Already Exists -> Run[/][heading]"
-                "kotobase db pull --force[/][danger] To Replace[/]"
-            )
-            raise typer.Exit(1) from None
+        builder.pull_audio(tag=tag, force=force)
 
 
 # --- Cache Commands ---
@@ -887,15 +815,58 @@ def cache_size() -> None:
     out.render_cache_size(sizes)
 
 
-if __name__ == "__main__":
+def _render_error(exc: KotobaseError) -> None:
+    """
+    Render a Kotobase error as a themed, user-friendly message
+
+    Args:
+        exc (KotobaseError): The error raised while running a command
+    """
+    if isinstance(exc, AudioDatabaseNotFoundError):
+        THEMED_CONSOLE.print(
+            "[danger]⊗ Couldn't Find The Audio Database -> Run [/]"
+            "[heading]kotobase db pull[/][danger] Or "
+            "[/][heading]kotobase db build[/]"
+        )
+    elif isinstance(exc, DatabaseNotFoundError):
+        THEMED_CONSOLE.print(
+            "[danger]⊗ Couldn't Find The Core Database -> Run [/]"
+            "[heading]kotobase db pull[/][danger] Or "
+            "[/][heading]kotobase db build[/]"
+        )
+    elif isinstance(exc, DatabaseExistsError):
+        THEMED_CONSOLE.print(
+            f"[danger]⊗ {exc}[/]  [muted](Use --force To Replace)[/]"
+        )
+    elif isinstance(exc, DownloadError):
+        THEMED_CONSOLE.print(f"[danger]⊗ Download Failed -> {exc}[/]")
+    elif isinstance(exc, SourceExtractionError):
+        THEMED_CONSOLE.print(f"[danger]⊗ Source Processing Failed -> {exc}[/]")
+    else:
+        THEMED_CONSOLE.print(f"[danger]⊗ {exc}[/]")
+
+
+def main() -> None:
+    """
+    CLI entry point
+
+    Forces UTF-8 output and renders [`KotobaseError`][kotobase.exceptions]
+    failures as friendly messages with a non-zero exit instead of tracebacks
+    """
     # Force UTF-8 on stdout and stderr so Japanese text survives redirection.
     # On Windows, a redirected stream defaults to a legacy code page (cp1252)
     # that cannot encode kana or kanji, which otherwise crashes piped or `>`
     # output
-
     if isinstance(sys.stdout, io.TextIOWrapper):
         sys.stdout.reconfigure(encoding="utf-8")
     if isinstance(sys.stderr, io.TextIOWrapper):
         sys.stderr.reconfigure(encoding="utf-8")
+    try:
+        app()
+    except KotobaseError as exc:
+        _render_error(exc)
+        raise SystemExit(1) from exc
 
-    app()
+
+if __name__ == "__main__":
+    main()

--- a/kotobase/src/kotobase/db/builder/build.py
+++ b/kotobase/src/kotobase/db/builder/build.py
@@ -35,6 +35,7 @@ from typing import Any
 import zstandard
 from sqlalchemy import create_engine
 
+from ...exceptions import DatabaseExistsError
 from ...terminal_output import (
     THEMED_CONSOLE,
     build_status,
@@ -428,12 +429,12 @@ def build_core(
         The path of the compiled database
 
     Raises:
-        FileExistsError: If a database already exists and `force` is False
+        DatabaseExistsError: If a database already exists and `force` is False
     """
     config.ensure_dirs()
     target = config.db_path()
     if target.exists() and not force:
-        raise FileExistsError(
+        raise DatabaseExistsError(
             f"Database Already Exists At '{target}', Pass Force To Rebuild"
         )
 
@@ -506,12 +507,12 @@ def build_audio(*, force: bool = False) -> Path:
         The path of the compiled audio pack
 
     Raises:
-        FileExistsError: If the pack already exists and `force` is False
+        DatabaseExistsError: If the pack already exists and `force` is False
     """
     config.ensure_dirs()
     pack = config.audio_db_path()
     if pack.exists() and not force:
-        raise FileExistsError(
+        raise DatabaseExistsError(
             f"Audio Pack Database Already Exists At '{pack}', Pass Force To"
             f" Rebuild"
         )

--- a/kotobase/src/kotobase/db/builder/download.py
+++ b/kotobase/src/kotobase/db/builder/download.py
@@ -29,6 +29,7 @@ from typing import Any
 import requests
 import zstandard
 
+from ...exceptions import DatabaseExistsError, DownloadError
 from ...terminal_output import THEMED_CONSOLE, download_progress_bar
 from .config import (
     AUDIO_ASSET,
@@ -90,11 +91,11 @@ def _get_github_asset_url(
         Tuple containing the name of the assets and its download URL
 
     Raises:
-        requests.HTTPError: If the GitHub API request fails
-        RuntimeError: If `asset` is not present on the `tag` / latest release,
-            if the `asset` regex expression (when `regex=True`) has no matches
-            in the `tag` / latest release, if the tag / latest release of
-            `repo` has no assets, or if the api's `JSON` response is malformed
+        DownloadError: If the GitHub API request fails, if `asset` is not
+            present on the `tag` / latest release, if the `asset` regex
+            expression (when `regex=True`) has no matches in the `tag` / latest
+            release, if the tag / latest release of `repo` has no assets, or if
+            the api's `JSON` response is malformed
     """
 
     # Resolve Tag
@@ -130,17 +131,22 @@ def _get_github_asset_url(
             timeout=30,
         )
 
-    response.raise_for_status()
+    try:
+        response.raise_for_status()
+    except requests.RequestException as e:
+        raise DownloadError(
+            f"GitHub API Request Failed For '{api}' : {e}"
+        ) from e
     try:
         resp_json: dict[str, Any] = response.json()
     except ValueError as e:
-        raise RuntimeError(f"Received Malformed API Response : {e}") from e
+        raise DownloadError(f"Received Malformed API Response : {e}") from e
 
     if not isinstance(resp_json, dict):
-        raise RuntimeError("Received Malformed API Response")
+        raise DownloadError("Received Malformed API Response")
 
     if "assets" not in resp_json:
-        raise RuntimeError(f"Release '{api}' Has No Assets")
+        raise DownloadError(f"Release '{api}' Has No Assets")
 
     if asset is None:
         first = resp_json["assets"][0]
@@ -153,7 +159,7 @@ def _get_github_asset_url(
             None,
         )
         if chosen is None:
-            raise RuntimeError(
+            raise DownloadError(
                 f"No Matching Release Asset Found For '{asset!r}' In "
                 f"'{api}' Release"
             )
@@ -163,7 +169,7 @@ def _get_github_asset_url(
             (a for a in resp_json["assets"] if a["name"] == asset), None
         )
         if chosen is None:
-            raise RuntimeError(
+            raise DownloadError(
                 f"No Matching Release Asset Found For '{asset}' In "
                 f"'{api}' Release"
             )
@@ -190,8 +196,8 @@ def resolve_upstream_source(
         A tuple of the local filename to save under and the URL to fetch
 
     Raises:
-        ValueError: If the source has neither a URL nor a GitHub repository
-        RuntimeError: If a matching GitHub release asset cannot be found
+        DownloadError: If the source has neither a URL nor a GitHub repository,
+            or if a matching GitHub release asset cannot be found
     """
     if source.url:
         name = source.url.split("?")[0].rstrip("/").split("/")[-1]
@@ -200,7 +206,7 @@ def resolve_upstream_source(
         return name, source.url
 
     if not source.github_repo:
-        raise ValueError(
+        raise DownloadError(
             f"Source '{source.key!r}' Has No `url` or `github_repo`"
         )
     if source.asset_pattern:
@@ -240,22 +246,28 @@ def _download_stream(
             task when download end
 
     Raises:
-        requests.HTTPError: If the download request fails
+        DownloadError: If the download fails for any reason
     """
     part = dest.with_name(dest.name + ".part")
-    with session.get(url, stream=True, timeout=120) as response:
-        response.raise_for_status()
-        # Get File Size
-        total = int(response.headers.get("content-length", 0)) or None
-        with download_progress_bar() as progress:
-            task = progress.add_task(label, total=total)
-            with open(part, "wb") as handle:
-                for chunk in response.iter_content(chunk_size=65536):
-                    handle.write(chunk)
-                    progress.update(task, advance=len(chunk))
-            if clear:
-                progress.update(task, visible=False)
-    part.replace(dest)
+    try:
+        with session.get(url, stream=True, timeout=120) as response:
+            response.raise_for_status()
+            # Get File Size
+            total = int(response.headers.get("content-length", 0)) or None
+            with download_progress_bar() as progress:
+                task = progress.add_task(label, total=total)
+                with open(part, "wb") as handle:
+                    for chunk in response.iter_content(chunk_size=65536):
+                        handle.write(chunk)
+                        progress.update(task, advance=len(chunk))
+                if clear:
+                    progress.update(task, visible=False)
+        part.replace(dest)
+    except Exception as e:
+        part.unlink(missing_ok=True)
+        raise DownloadError(
+            f"Couldn't Download File At '{url}' : '{e}'"
+        ) from e
 
 
 def download(
@@ -272,6 +284,9 @@ def download(
         force (bool): When True, re download even if the file already exists
         session (requests.Session | None): Optional shared session, a new one
             is created when omitted
+
+    Raises:
+        DownloadError: If the download fails for any reason
 
     Returns:
         The path of the downloaded file
@@ -321,7 +336,7 @@ def download_all(
             sources that failed left out
 
     Raises:
-        requests.HTTPError: If a required source fails to download
+        DownloadError: If a required source fails to download
     """
     session = session or _session()
     if keys is None:
@@ -334,7 +349,7 @@ def download_all(
         source = SOURCES[key]
         try:
             result[key] = download(source, force=force, session=session)
-        except Exception as e:
+        except DownloadError as e:
             if source.optional:
                 THEMED_CONSOLE.print(
                     f"[warning]Skipping Optional Source Failure[/] For [info]"
@@ -359,8 +374,8 @@ def _download_and_decompress(url: str, destination: Path, label: str) -> None:
         label (str): Short label shown on the progress bar
 
     Raises:
-        requests.HTTPError: If the download request fails
-        Exception: If any I/O or network error occurs
+        DownloadError: If the download request fails,
+            or any I/O or network error occurs
     """
     part = destination.with_name(destination.name + ".part")
     decompressor = zstandard.ZstdDecompressor()
@@ -404,12 +419,12 @@ def _download_and_decompress(url: str, destination: Path, label: str) -> None:
     except Exception as e:
         # All context managers are closed here, freeing file write locks
         part.unlink(missing_ok=True)
-        raise e
+        raise DownloadError(f"Failed To Download {url} : {e}") from e
 
 
 def pull_db(*, tag: str | None = None, force: bool = False) -> Path:
     """
-    Downloada and decompresses the prebuilt core database
+    Downloads and decompresses the prebuilt core database
 
     Args:
         tag (str | None): Release tag to pull from, or None for the latest
@@ -419,12 +434,13 @@ def pull_db(*, tag: str | None = None, force: bool = False) -> Path:
         The path of the decompressed database
 
     Raises:
-        FileExistsError: If the database already exists and `force` is False
+        DatabaseExistsError: If the database already exists and `force` is
+            False
     """
     ensure_dirs()
     destination = db_path()
     if destination.exists() and not force:
-        raise FileExistsError(
+        raise DatabaseExistsError(
             f"Core Database Already Exists At '{destination}',"
             f" Pass Force To Replace"
         )
@@ -447,12 +463,13 @@ def pull_audio(*, tag: str | None = None, force: bool = False) -> Path:
         The path of the decompressed audio pack
 
     Raises:
-        FileExistsError: If the audio pack already exists and `force` is False
+        DatabaseExistsError: If the audio pack already exists and `force` is
+            False
     """
     ensure_dirs()
     destination = audio_db_path()
     if destination.exists() and not force:
-        raise FileExistsError(
+        raise DatabaseExistsError(
             f"Audio Pack Database Already Exists At '{destination}', Pass"
             f" Force To Replace"
         )

--- a/kotobase/src/kotobase/db/builder/extractors.py
+++ b/kotobase/src/kotobase/db/builder/extractors.py
@@ -46,6 +46,7 @@ import bz2
 import csv
 import gzip
 import json
+import logging
 import re
 import tarfile
 import zipfile
@@ -56,7 +57,12 @@ from typing import Any, TypeAlias
 
 from lxml import etree
 
+from ...exceptions import MalformedSourceError, SourceExtractionError
 from . import config
+
+# --- Module Logger ---
+
+LOGGER = logging.getLogger(__name__)
 
 # --- Extractor Contract ---
 
@@ -172,14 +178,16 @@ def _require_int(value: str | None) -> int:
         The parsed integer
 
     Raises:
-        ValueError: If the text is missing or can't be parsed
+        MalformedSourceError: If the text is missing or can't be parsed
     """
     if value is None:
-        raise ValueError("Missing Required Integer Field")
+        raise MalformedSourceError("Missing Required Integer Field")
     try:
         return int(value)
     except ValueError as e:
-        raise ValueError("Required Integer Field Can't Be Parsed") from e
+        raise MalformedSourceError(
+            f"Required Integer Field '{value}' Can't Be Parsed"
+        ) from e
 
 
 def stream_elements(
@@ -390,10 +398,10 @@ def _read_tar_bz2_member(path: Path, suffix: str) -> Iterator[list[str]]:
             None,
         )
         if member is None:
-            raise FileNotFoundError(f"No Member Ending In '{suffix!r}'")
+            raise SourceExtractionError(f"No Member Ending In '{suffix!r}'")
         handle = archive.extractfile(member)
         if handle is None:
-            raise FileNotFoundError(
+            raise SourceExtractionError(
                 f"No Data Found For Member With Suffix '{suffix}'"
             )
         for raw in handle:
@@ -999,10 +1007,10 @@ def extract_furigana(path: Path) -> Iterator[DatabaseRow]:
             None,
         )
         if member is None:
-            raise FileNotFoundError(f"No JSON Member In '{path}'")
+            raise SourceExtractionError(f"No JSON Member In '{path}'")
         handle = archive.extractfile(member)
         if handle is None:
-            raise FileNotFoundError(f"Couldn't Read '{member.name}'")
+            raise SourceExtractionError(f"Couldn't Read '{member.name}'")
         records = json.load(handle)
 
     for record in records:

--- a/kotobase/src/kotobase/db/connection.py
+++ b/kotobase/src/kotobase/db/connection.py
@@ -15,7 +15,7 @@ info: Pre-Requisite
       [`Build Pipeline`][kotobase.db.builder] and only queried here
 
     - Until it exists, every query fails with a
-      [`DatabaseNotFoundError`][kotobase.db.connection.DatabaseNotFoundError]
+      [`DatabaseNotFoundError`][kotobase.exceptions.DatabaseNotFoundError]
       that points the caller at the build or pull [`CLI`][kotobase.cli]
       commands
 """
@@ -31,20 +31,8 @@ from typing import Any
 from sqlalchemy import Engine, create_engine, event
 from sqlalchemy.orm import Session, sessionmaker
 
+from ..exceptions import DatabaseNotFoundError
 from .builder import config
-
-
-class DatabaseNotFoundError(RuntimeError):
-    """
-    Raised when a query is attempted before the database exists
-    """
-
-
-class AudioDatabaseNotFoundError(DatabaseNotFoundError):
-    """
-    Raised when audio bytes are requested but the optional audio pack is not
-    installed
-    """
 
 
 def _require_database() -> Path:

--- a/kotobase/src/kotobase/db/dtos.py
+++ b/kotobase/src/kotobase/db/dtos.py
@@ -1,80 +1,138 @@
 """
 Defines Kotobase's Data-Transfer-Objects
 
-The DTO's are the boundary between the database and the public API.
+The DTOs are the boundary between the database and the public API.
 [`Repositories`][kotobase.db.repos] return them rather than
 [`ORM`][kotobase.db.models] rows so that callers get plain, immutable,
-serializable objects that don't depend on an open session
+serializable values that don't depend on an open session
 
 info: Serialization
-    Every object inherits from [`Serializable`][kotobase.db.dtos.Serializable],
-    which adds `to_dict`, `to_json` and iteration to every DTO
+    Every DTO is a `Pydantic` model, serialize it with Pydantic's own
+    `model_dump` / `model_dump_json`, which keep Japanese text verbatim
 
 info: ORM Mapping
-    - Each object exposes a `from_orm` classmethod that builds it from a
-      loaded ORM row
+    - ORM-backed DTOs inherit from
+      [`SafeORMModel`][kotobase.db.dtos.SafeORMModel] and are built with
+      `model_validate`, reading attributes straight from a loaded ORM row
 
-    - Nested objects delegate to each other, so `JMDictEntryDTO.from_orm`
-      builds its senses through `SenseDTO.from_orm` and so on
+    - A model validator replaces any relationship that wasn't eagerly loaded
+      with `None`, so validation never triggers a lazy load, and overlays
+      values passed through the validation `context` for fields that aren't
+      plain ORM attributes, such as a kanji's radicals
 
-    - The classmethods expect the relationships they read to be eagerly-loaded
-      , which is done by the [`Repositories`][kotobase.db.repos]
+    - The [`Repositories`][kotobase.db.repos] eagerly load the relationships
+      each DTO reads
 """
 
 from __future__ import annotations
 
-import json
-from collections.abc import Iterator, Sequence
-from dataclasses import asdict, dataclass
-from dataclasses import field as dfield
-from typing import Any
+from typing import Any, Protocol, TypeAlias
 
-from . import models as orm
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationInfo,
+    field_validator,
+    model_validator,
+)
+from sqlalchemy import inspect
+from sqlalchemy.orm import base
 
 
-class Serializable:
+class SafeORMModel(BaseModel):
     """
-    Mixin that adds `dict` + `JSON` serialization to a python dataclass
+    Pydantic base model for ORM-backed DTOs that tolerates unloaded
+    relationships
+
+    Validates directly from `SQLAlchemy` instances (`from_attributes`), but
+    first replaces any relationship field that wasn't eagerly loaded with
+    `None` instead of triggering a lazy load, and overlays any values supplied
+    through the validation `context`
     """
 
-    def to_dict(self) -> dict[str, Any]:
-        """
-        Converts the object to a plain dictionary
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
-        Returns:
-            A nested dictionary of the `dataclass` fields
+    @model_validator(mode="before")
+    @classmethod
+    def check_sqlalchemy_state(cls, data: Any, info: ValidationInfo) -> Any:
         """
-        return asdict(self)  # type: ignore[call-overload,no-any-return]
+        Builds a validation-safe mapping from a `SQLAlchemy` instance
 
-    def to_json(self, **json_kwargs: Any) -> str:
-        """
-        Converts the object to a `JSON` string
+        Reads each field from its ORM attribute (honoring a field's validation
+        alias), maps unloaded relationships to `None` so that validation never
+        triggers a lazy load, then overlays any matching keys from the
+        validation `context`. Inputs that aren't SQLAlchemy instances are
+        returned unchanged
 
         Args:
-            **json_kwargs (Any): Extra keyword arguments forwarded to
-                `json.dumps`
+            data (Any): The value being validated (ORM instance or mapping)
+            info (ValidationInfo): Validation context carrying injected fields
 
         Returns:
-            The object encoded as compact `JSON` with non-ASCII characters
-                kept verbatim
+            A mapping safe for Pydantic validation, or `data` unchanged when
+                it isn't a `SQLAlchemy` instance
         """
-        json_kwargs.setdefault("ensure_ascii", False)
-        json_kwargs.setdefault("separators", (",", ":"))
-        return json.dumps(self.to_dict(), **json_kwargs)
 
-    def __iter__(self) -> Iterator[tuple[str, Any]]:
-        """
-        Iterates over the object's fields as key and value pairs
+        # Check If The Object is an SQLAlchemy Instance
+        state = inspect(data, raiseerr=False)
+        if state is None:
+            # Return Input Object Unchanged
+            return data
 
-        Yields:
-            Each field name paired with its value
+        # Relationships not eagerly loaded, and attributes already in memory
+        unloaded_fields = state.unloaded
+        loaded_data = base.instance_dict(data)
+
+        # Build A Safe Dictionary For Pydantic
+        safe_dict: dict[str, Any] = {}
+        for field_name, field in cls.model_fields.items():
+            # A field may read from a differently named ORM attribute
+            alias = field.validation_alias
+            source = alias if isinstance(alias, str) else field_name
+            if source in unloaded_fields:
+                # Relationship not loaded, avoid triggering a lazy load
+                safe_dict[field_name] = None
+            elif source in loaded_data:
+                safe_dict[field_name] = loaded_data[source]
+            else:
+                # Calculated fields / hybrids not present in instance_dict
+                safe_dict[field_name] = getattr(data, source, None)
+
+        # Overlay repo-injected fields that aren't plain ORM attributes
+        if info.context:
+            safe_dict.update(
+                {
+                    key: value
+                    for key, value in info.context.items()
+                    if key in cls.model_fields
+                }
+            )
+        return safe_dict
+
+
+class Keyed(Protocol):
+    """
+    Interface for a DTO that carries its own lookup key
+
+    The public API accepts these DTOs anywhere a string key is expected and
+    reads the key straight off the object, so a result from one call can be
+    passed into another without unpacking a field by hand
+    """
+
+    @property
+    def key(self) -> str:
         """
-        yield from self.to_dict().items()
+        Return the DTO's natural lookup key
+
+        Returns:
+            The key string, such as a kanji literal or an entry's headword
+        """
+        ...
 
 
 # --- JMdict ---
-@dataclass(slots=True)
-class GlossDTO(Serializable):
+class GlossDTO(SafeORMModel):
     """
     A single translation of a `JMdict` sense
 
@@ -90,27 +148,8 @@ class GlossDTO(Serializable):
     gender: str | None = None
     gtype: str | None = None
 
-    @classmethod
-    def from_orm(cls, gloss: orm.JMDictGloss) -> GlossDTO:
-        """
-        Build a gloss from an ORM gloss row
 
-        Args:
-            gloss (orm.JMDictGloss): The ORM gloss row
-
-        Returns:
-            The gloss as a data transfer object
-        """
-        return cls(
-            text=gloss.text,
-            lang=gloss.lang,
-            gender=gloss.gender,
-            gtype=gloss.gtype,
-        )
-
-
-@dataclass(slots=True)
-class SenseDTO(Serializable):
+class SenseDTO(SafeORMModel):
     """
     One meaning of a `JMdict` entry with its glosses and tags
 
@@ -126,42 +165,41 @@ class SenseDTO(Serializable):
         lsource (list[dict]): Source language records for loanwords
     """
 
-    glosses: list[GlossDTO] = dfield(default_factory=list)
-    pos: list[str] = dfield(default_factory=list)
-    field: list[str] = dfield(default_factory=list)
-    misc: list[str] = dfield(default_factory=list)
-    dialect: list[str] = dfield(default_factory=list)
-    info: list[str] = dfield(default_factory=list)
-    xref: list[str] = dfield(default_factory=list)
-    antonym: list[str] = dfield(default_factory=list)
-    lsource: list[dict[str, Any]] = dfield(default_factory=list)
+    glosses: list[GlossDTO] = Field(default_factory=list)
+    pos: list[str] = Field(default_factory=list)
+    field: list[str] = Field(default_factory=list)
+    misc: list[str] = Field(default_factory=list)
+    dialect: list[str] = Field(default_factory=list)
+    info: list[str] = Field(default_factory=list)
+    xref: list[str] = Field(default_factory=list)
+    antonym: list[str] = Field(default_factory=list)
+    lsource: list[dict[str, Any]] = Field(default_factory=list)
 
-    @classmethod
-    def from_orm(cls, sense: orm.JMDictSense) -> SenseDTO:
+    def all_tags(self) -> list[str]:
         """
-        Build a sense from an ORM sense row
-
-        Args:
-            sense (orm.JMDictSense): The ORM sense row with its glosses loaded
+        Return every tag code attached to the sense
 
         Returns:
-            The sense as a data transfer object
+            The pos, field, misc and dialect codes concatenated in that order
         """
-        return cls(
-            glosses=[GlossDTO.from_orm(gloss) for gloss in sense.glosses],
-            pos=sense.pos,
-            field=sense.field,
-            misc=sense.misc,
-            dialect=sense.dialect,
-            info=sense.info,
-            xref=sense.xref,
-            antonym=sense.antonym,
-            lsource=sense.lsource,
-        )
+        return [*self.pos, *self.field, *self.misc, *self.dialect]
+
+    def expand_tags(self, labels: dict[str, str]) -> list[str]:
+        """
+        Resolve the sense's tag codes to human descriptions
+
+        Args:
+            labels (dict[str, str]): A code to description map, such as the one
+                on [`LookupResult.labels`][kotobase.db.dtos.LookupResult]
+
+        Returns:
+            One description per tag code, falling back to the raw code when it
+                isn't present in the map
+        """
+        return [labels.get(code, code) for code in self.all_tags()]
 
 
-@dataclass(slots=True)
-class KanjiFormDTO(Serializable):
+class KanjiFormDTO(SafeORMModel):
     """
     A written form of a `JMdict` entry
 
@@ -174,30 +212,21 @@ class KanjiFormDTO(Serializable):
 
     text: str
     is_common: bool = False
-    info: list[str] = dfield(default_factory=list)
-    priority: list[str] = dfield(default_factory=list)
+    info: list[str] = Field(default_factory=list)
+    priority: list[str] = Field(default_factory=list)
 
-    @classmethod
-    def from_orm(cls, form: orm.JMDictKanji) -> KanjiFormDTO:
+    @property
+    def key(self) -> str:
         """
-        Build a kanji form from an ORM kanji form row
-
-        Args:
-            form (orm.JMDictKanji): The ORM kanji form row
+        Return the lookup key for this kanji form
 
         Returns:
-            The form as a data transfer object
+            The kanji spelling text
         """
-        return cls(
-            text=form.text,
-            is_common=form.is_common,
-            info=form.info,
-            priority=form.priority,
-        )
+        return self.text
 
 
-@dataclass(slots=True)
-class KanaFormDTO(Serializable):
+class KanaFormDTO(SafeORMModel):
     """
     A reading form of a `JMdict` entry
 
@@ -214,33 +243,22 @@ class KanaFormDTO(Serializable):
     text: str
     is_common: bool = False
     no_kanji: bool = False
-    restrictions: list[str] = dfield(default_factory=list)
-    info: list[str] = dfield(default_factory=list)
-    priority: list[str] = dfield(default_factory=list)
+    restrictions: list[str] = Field(default_factory=list)
+    info: list[str] = Field(default_factory=list)
+    priority: list[str] = Field(default_factory=list)
 
-    @classmethod
-    def from_orm(cls, form: orm.JMDictKana) -> KanaFormDTO:
+    @property
+    def key(self) -> str:
         """
-        Build a kana form from an ORM kana form row
-
-        Args:
-            form (orm.JMDictKana): The ORM kana form row
+        Return the lookup key for this kana form
 
         Returns:
-            The form as a data transfer object
+            The kana reading text
         """
-        return cls(
-            text=form.text,
-            is_common=form.is_common,
-            no_kanji=form.no_kanji,
-            restrictions=form.restrictions,
-            info=form.info,
-            priority=form.priority,
-        )
+        return self.text
 
 
-@dataclass(slots=True)
-class JMDictEntryDTO(Serializable):
+class JMDictEntryDTO(SafeORMModel):
     """
     One `JMdict` dictionary entry
 
@@ -257,30 +275,9 @@ class JMDictEntryDTO(Serializable):
     id: int
     is_common: bool = False
     freq_rank: int | None = None
-    kanji: list[KanjiFormDTO] = dfield(default_factory=list)
-    kana: list[KanaFormDTO] = dfield(default_factory=list)
-    senses: list[SenseDTO] = dfield(default_factory=list)
-
-    @classmethod
-    def from_orm(cls, entry: orm.JMDictEntry) -> JMDictEntryDTO:
-        """
-        Build an entry from an ORM entry row
-
-        Args:
-            entry (orm.JMDictEntry): The ORM entry with its forms and senses
-                eagerly-loaded
-
-        Returns:
-            The entry as a data transfer object
-        """
-        return cls(
-            id=entry.id,
-            is_common=entry.is_common,
-            freq_rank=entry.freq_rank,
-            kanji=[KanjiFormDTO.from_orm(form) for form in entry.kanji],
-            kana=[KanaFormDTO.from_orm(form) for form in entry.kana],
-            senses=[SenseDTO.from_orm(sense) for sense in entry.senses],
-        )
+    kanji: list[KanjiFormDTO] = Field(default_factory=list)
+    kana: list[KanaFormDTO] = Field(default_factory=list)
+    senses: list[SenseDTO] = Field(default_factory=list)
 
     @property
     def headword(self) -> str:
@@ -294,10 +291,62 @@ class JMDictEntryDTO(Serializable):
             return self.kanji[0].text
         return self.kana[0].text if self.kana else ""
 
+    @property
+    def key(self) -> str:
+        """
+        Return the lookup key for this entry
+
+        Returns:
+            The entry's headword
+        """
+        return self.headword
+
+    def common_kanji(self) -> list[KanjiFormDTO]:
+        """
+        Return only the written forms flagged common
+
+        Returns:
+            The kanji forms whose `is_common` is True
+        """
+        return [form for form in self.kanji if form.is_common]
+
+    def common_kana(self) -> list[KanaFormDTO]:
+        """
+        Return only the reading forms flagged common
+
+        Returns:
+            The kana forms whose `is_common` is True
+        """
+        return [form for form in self.kana if form.is_common]
+
+    def all_pos(self) -> list[str]:
+        """
+        Return the unique part-of-speech codes used across every sense
+
+        Returns:
+            The part-of-speech codes in first-seen order, without duplicates
+        """
+        seen: dict[str, None] = {}
+        for sense in self.senses:
+            for code in sense.pos:
+                seen.setdefault(code, None)
+        return list(seen)
+
+    def senses_with_pos(self, code: str) -> list[SenseDTO]:
+        """
+        Return the senses that carry a given part-of-speech code
+
+        Args:
+            code (str): The part-of-speech tag code to match
+
+        Returns:
+            The senses whose `pos` contains the code
+        """
+        return [sense for sense in self.senses if code in sense.pos]
+
 
 # --- JMnedict ---
-@dataclass(slots=True)
-class NameTranslationDTO(Serializable):
+class NameTranslationDTO(SafeORMModel):
     """
     A translation block of a `JMnedict` name
 
@@ -307,31 +356,32 @@ class NameTranslationDTO(Serializable):
         xref (list[str]): Cross references to related entries
     """
 
-    name_type: list[str] = dfield(default_factory=list)
-    translations: list[str] = dfield(default_factory=list)
-    xref: list[str] = dfield(default_factory=list)
+    name_type: list[str] = Field(default_factory=list)
+    translations: list[str] = Field(
+        default_factory=list, validation_alias="glosses"
+    )
+    xref: list[str] = Field(default_factory=list)
 
+    @field_validator("translations", mode="before")
     @classmethod
-    def from_orm(cls, block: orm.JMnedictTranslation) -> NameTranslationDTO:
+    def _glosses_to_text(cls, value: Any) -> Any:
         """
-        Build a translation block from an ORM translation row
+        Flatten `JMnedictGloss` rows to their text when validating from ORM
 
         Args:
-            block (orm.JMnedictTranslation): The ORM translation block with its
-                glosses loaded
+            value (Any): The raw `translations` input, a list of
+                [`JMNedictGloss`][kotobase.db.models.JMNedictGloss]
+                rows or strings
 
         Returns:
-            The translation block as a data transfer object
+            A list of gloss strings, or the value unchanged when not a list
         """
-        return cls(
-            name_type=block.name_type,
-            translations=[gloss.text for gloss in block.glosses],
-            xref=block.xref,
-        )
+        if isinstance(value, list):
+            return [getattr(item, "text", item) for item in value]
+        return value
 
 
-@dataclass(slots=True)
-class JMNeDictEntryDTO(Serializable):
+class JMNeDictEntryDTO(SafeORMModel):
     """
     One `JMnedict` proper name entry
 
@@ -343,31 +393,28 @@ class JMNeDictEntryDTO(Serializable):
     """
 
     id: int
-    kanji: list[str] = dfield(default_factory=list)
-    kana: list[str] = dfield(default_factory=list)
-    translations: list[NameTranslationDTO] = dfield(default_factory=list)
+    kanji: list[str] = Field(default_factory=list)
+    kana: list[str] = Field(default_factory=list)
+    translations: list[NameTranslationDTO] = Field(default_factory=list)
 
+    @field_validator("kanji", "kana", mode="before")
     @classmethod
-    def from_orm(cls, entry: orm.JMnedictEntry) -> JMNeDictEntryDTO:
+    def _forms_to_text(cls, value: Any) -> Any:
         """
-        Build a name entry from an ORM entry row
+        Flatten `JMnedict` kanji / kana rows to their text from ORM
 
         Args:
-            entry (orm.JMnedictEntry): The ORM entry with its forms and
-                translations eagerly-loaded
+            value (Any): The raw form input, a list of
+            [`JMnedictKanji`][kotobase.db.models.JMNedictKanji] /
+            [`JMnedictKana`][kotobase.db.models.JMNedictKana]
+            rows or strings
 
         Returns:
-            The entry as a data transfer object
+            A list of form strings, or the value unchanged when not a list
         """
-        return cls(
-            id=entry.id,
-            kanji=[form.text for form in entry.kanji],
-            kana=[form.text for form in entry.kana],
-            translations=[
-                NameTranslationDTO.from_orm(block)
-                for block in entry.translations
-            ],
-        )
+        if isinstance(value, list):
+            return [getattr(item, "text", item) for item in value]
+        return value
 
     @property
     def headword(self) -> str:
@@ -381,10 +428,19 @@ class JMNeDictEntryDTO(Serializable):
             return self.kanji[0]
         return self.kana[0] if self.kana else ""
 
+    @property
+    def key(self) -> str:
+        """
+        Return the lookup key for this name entry
+
+        Returns:
+            The name entry's headword
+        """
+        return self.headword
+
 
 # --- Kanji ---
-@dataclass(slots=True)
-class KanjiDTO(Serializable):
+class KanjiDTO(SafeORMModel):
     """
     A kanji with its full `KanjiDic2` and `KanjiVG` profile
 
@@ -418,72 +474,77 @@ class KanjiDTO(Serializable):
     freq: int | None = None
     jlpt_old: int | None = None
     jlpt_tanos: int | None = None
-    onyomi: list[str] = dfield(default_factory=list)
-    kunyomi: list[str] = dfield(default_factory=list)
-    nanori: list[str] = dfield(default_factory=list)
-    pinyin: list[str] = dfield(default_factory=list)
-    korean: list[str] = dfield(default_factory=list)
-    meanings: list[str] = dfield(default_factory=list)
-    radicals: list[str] = dfield(default_factory=list)
-    dic_refs: dict[str, str] = dfield(default_factory=dict)
-    query_codes: dict[str, list[str]] = dfield(default_factory=dict)
-    codepoints: dict[str, str] = dfield(default_factory=dict)
-    variants: list[dict[str, Any]] = dfield(default_factory=list)
+    onyomi: list[str] = Field(default_factory=list)
+    kunyomi: list[str] = Field(default_factory=list)
+    nanori: list[str] = Field(default_factory=list)
+    pinyin: list[str] = Field(default_factory=list)
+    korean: list[str] = Field(default_factory=list)
+    meanings: list[str] = Field(default_factory=list)
+    radicals: list[str] = Field(default_factory=list)
+    dic_refs: dict[str, str] = Field(default_factory=dict)
+    query_codes: dict[str, list[str]] = Field(default_factory=dict)
+    codepoints: dict[str, str] = Field(default_factory=dict)
+    variants: list[dict[str, Any]] = Field(default_factory=list)
     has_stroke_order: bool = False
 
-    @classmethod
-    def from_orm(
-        cls,
-        kanji: orm.Kanji,
-        *,
-        radicals: Sequence[str] = (),
-        jlpt_tanos: int | None = None,
-    ) -> KanjiDTO:
+    @property
+    def key(self) -> str:
         """
-        Build a kanji profile from an ORM kanji row
-
-        Args:
-            kanji (orm.Kanji): The ORM kanji with its readings, meanings,
-                nanori, dic refs, query codes, variants, codepoints and stroke
-                data eagerly-loaded
-            radicals (Sequence[str]): Radical components for the kanji, which
-                are not a direct relationship and so are passed in
-            jlpt_tanos (int | None): The Tanos JLPT level when known
+        Return the lookup key for this kanji
 
         Returns:
-            The kanji as a data transfer object
+            The kanji literal character
         """
-        query_codes: dict[str, list[str]] = {}
-        for code in kanji.query_codes:
-            query_codes.setdefault(code.type, []).append(code.value)
-        korean = ("korean_r", "korean_h")
-        return cls(
-            literal=kanji.literal,
-            grade=kanji.grade,
-            stroke_count=kanji.stroke_count,
-            freq=kanji.freq,
-            jlpt_old=kanji.jlpt_old,
-            jlpt_tanos=jlpt_tanos,
-            onyomi=[r.value for r in kanji.readings if r.type == "ja_on"],
-            kunyomi=[r.value for r in kanji.readings if r.type == "ja_kun"],
-            nanori=[n.value for n in kanji.nanori],
-            pinyin=[r.value for r in kanji.readings if r.type == "pinyin"],
-            korean=[r.value for r in kanji.readings if r.type in korean],
-            meanings=[m.value for m in kanji.meanings if m.lang == "en"],
-            radicals=list(radicals),
-            dic_refs={ref.type: ref.value for ref in kanji.dic_refs},
-            query_codes=query_codes,
-            codepoints={cp.type: cp.value for cp in kanji.codepoints},
-            variants=[
-                {"type": v.type, "value": v.value} for v in kanji.variants
-            ],
-            has_stroke_order=kanji.strokes is not None,
-        )
+        return self.literal
+
+    def skip_codes(self) -> list[str]:
+        """
+        Return the SKIP query codes for the kanji
+
+        Returns:
+            The SKIP codes, or an empty list when none are recorded
+        """
+        return self.query_codes.get("skip", [])
+
+    def four_corner_codes(self) -> list[str]:
+        """
+        Return the Four Corner query codes for the kanji
+
+        Returns:
+            The Four Corner codes, or an empty list when none are recorded
+        """
+        return self.query_codes.get("four_corner", [])
+
+    def primary_onyomi(self) -> str | None:
+        """
+        Return the first on reading
+
+        Returns:
+            The first on reading, or None when there are none
+        """
+        return self.onyomi[0] if self.onyomi else None
+
+    def primary_kunyomi(self) -> str | None:
+        """
+        Return the first kun reading
+
+        Returns:
+            The first kun reading, or None when there are none
+        """
+        return self.kunyomi[0] if self.kunyomi else None
+
+    def is_joyo(self) -> bool:
+        """
+        Report whether the kanji is in the Joyo set
+
+        Returns:
+            True when the KanjiDic grade is 1 through 8
+        """
+        return self.grade is not None and self.grade <= 8
 
 
 # --- Furigana, Sentences, JLPT ---
-@dataclass(slots=True)
-class FuriganaDTO(Serializable):
+class FuriganaDTO(SafeORMModel):
     """
     Furigana segmentation for a spelling and reading pair
 
@@ -495,28 +556,10 @@ class FuriganaDTO(Serializable):
 
     text: str
     reading: str
-    segments: list[dict[str, Any]] = dfield(default_factory=list)
-
-    @classmethod
-    def from_orm(cls, row: orm.Furigana) -> FuriganaDTO:
-        """
-        Build a furigana object from an ORM furigana row
-
-        Args:
-            row (orm.Furigana): The ORM furigana row
-
-        Returns:
-            The row as a data transfer object
-        """
-        return cls(
-            text=row.text,
-            reading=row.reading,
-            segments=row.segments,
-        )
+    segments: list[dict[str, Any]] = Field(default_factory=list)
 
 
-@dataclass(slots=True)
-class SentenceDTO(Serializable):
+class SentenceDTO(SafeORMModel):
     """
     A `Tatoeba` example sentence with its translations
 
@@ -530,35 +573,10 @@ class SentenceDTO(Serializable):
     id: int
     text: str
     lang: str = "jpn"
-    translations: list[str] = dfield(default_factory=list)
-
-    @classmethod
-    def from_orm(
-        cls,
-        row: orm.Sentence,
-        *,
-        translations: Sequence[str] = (),
-    ) -> SentenceDTO:
-        """
-        Build a sentence from an ORM sentence row
-
-        Args:
-            row (orm.Sentence): The ORM sentence row
-            translations (Sequence[str]): Aligned translation texts when known
-
-        Returns:
-            The row as a data transfer object
-        """
-        return cls(
-            id=row.id,
-            text=row.text,
-            lang=row.lang,
-            translations=list(translations),
-        )
+    translations: list[str] = Field(default_factory=list)
 
 
-@dataclass(slots=True)
-class JLPTVocabDTO(Serializable):
+class JLPTVocabDTO(SafeORMModel):
     """
     A Tanos JLPT vocabulary item
 
@@ -574,27 +592,18 @@ class JLPTVocabDTO(Serializable):
     reading: str | None = None
     meaning: str | None = None
 
-    @classmethod
-    def from_orm(cls, row: orm.JlptVocab) -> JLPTVocabDTO:
+    @property
+    def key(self) -> str:
         """
-        Build a JLPT vocabulary item from an ORM row
-
-        Args:
-            row (orm.JlptVocab): The ORM JLPT vocabulary row
+        Return the lookup key for this JLPT vocabulary item
 
         Returns:
-            The row as a data transfer object
+            The headword, falling back to the reading, or an empty string
         """
-        return cls(
-            level=row.level,
-            word=row.word,
-            reading=row.reading,
-            meaning=row.meaning,
-        )
+        return self.word or self.reading or ""
 
 
-@dataclass(slots=True)
-class JLPTKanjiDTO(Serializable):
+class JLPTKanjiDTO(SafeORMModel):
     """
     A Tanos JLPT kanji item
 
@@ -612,28 +621,18 @@ class JLPTKanjiDTO(Serializable):
     kun_yomi: str | None = None
     meaning: str | None = None
 
-    @classmethod
-    def from_orm(cls, row: orm.JlptKanji) -> JLPTKanjiDTO:
+    @property
+    def key(self) -> str:
         """
-        Build a JLPT kanji item from an ORM row
-
-        Args:
-            row (orm.JlptKanji): The ORM JLPT kanji row
+        Return the lookup key for this JLPT kanji item
 
         Returns:
-            The row as a data transfer object
+            The kanji character
         """
-        return cls(
-            level=row.level,
-            kanji=row.kanji,
-            on_yomi=row.on_yomi,
-            kun_yomi=row.kun_yomi,
-            meaning=row.meaning,
-        )
+        return self.kanji
 
 
-@dataclass(slots=True)
-class JLPTGrammarDTO(Serializable):
+class JLPTGrammarDTO(SafeORMModel):
     """
     A Tanos JLPT grammar point
 
@@ -647,30 +646,11 @@ class JLPTGrammarDTO(Serializable):
     level: int
     grammar: str
     formation: str | None = None
-    examples: list[str] = dfield(default_factory=list)
-
-    @classmethod
-    def from_orm(cls, row: orm.JlptGrammar) -> JLPTGrammarDTO:
-        """
-        Build a JLPT grammar point from an ORM row
-
-        Args:
-            row (orm.JlptGrammar): The ORM JLPT grammar row
-
-        Returns:
-            The row as a data transfer object
-        """
-        return cls(
-            level=row.level,
-            grammar=row.grammar,
-            formation=row.formation,
-            examples=row.examples,
-        )
+    examples: list[str] = Field(default_factory=list)
 
 
 # --- Radicals, Audio ---
-@dataclass(slots=True)
-class RadicalDTO(Serializable):
+class RadicalDTO(SafeORMModel):
     """
     A search radical and its stroke count
 
@@ -682,22 +662,18 @@ class RadicalDTO(Serializable):
     radical: str
     stroke_count: int | None = None
 
-    @classmethod
-    def from_orm(cls, row: orm.Radical) -> RadicalDTO:
+    @property
+    def key(self) -> str:
         """
-        Build a radical from an ORM radical row
-
-        Args:
-            row (orm.Radical): The ORM radical row
+        Return the lookup key for this radical
 
         Returns:
-            The row as a data transfer object
+            The radical character
         """
-        return cls(radical=row.radical, stroke_count=row.stroke_count)
+        return self.radical
 
 
-@dataclass(slots=True)
-class AudioDTO(Serializable):
+class AudioDTO(SafeORMModel):
     """
     Metadata for a pronunciation audio clip
 
@@ -719,31 +695,9 @@ class AudioDTO(Serializable):
     license: str | None = None
     attribution: str | None = None
 
-    @classmethod
-    def from_orm(cls, row: orm.Audio) -> AudioDTO:
-        """
-        Build audio metadata from an ORM audio row
-
-        Args:
-            row (orm.Audio): The ORM audio row
-
-        Returns:
-            The row as a data transfer object, without the raw bytes
-        """
-        return cls(
-            kind=row.kind,
-            key=row.key,
-            reading=row.reading,
-            fmt=row.fmt,
-            source=row.source,
-            license=row.license,
-            attribution=row.attribution,
-        )
-
 
 # --- Aggregate Lookup Result ---
-@dataclass(slots=True)
-class LookupResult(Serializable):
+class LookupResult(BaseModel):
     """
     The aggregated result of a comprehensive word lookup
 
@@ -763,15 +717,51 @@ class LookupResult(Serializable):
     """
 
     query: str
-    entries: list[JMDictEntryDTO] = dfield(default_factory=list)
-    names: list[JMNeDictEntryDTO] = dfield(default_factory=list)
-    kanji: list[KanjiDTO] = dfield(default_factory=list)
-    furigana: list[FuriganaDTO] = dfield(default_factory=list)
+    entries: list[JMDictEntryDTO] = Field(default_factory=list)
+    names: list[JMNeDictEntryDTO] = Field(default_factory=list)
+    kanji: list[KanjiDTO] = Field(default_factory=list)
+    furigana: list[FuriganaDTO] = Field(default_factory=list)
     jlpt_vocab: JLPTVocabDTO | None = None
-    jlpt_kanji_levels: dict[str, int] = dfield(default_factory=dict)
-    jlpt_grammar: list[JLPTGrammarDTO] = dfield(default_factory=list)
-    sentences: list[SentenceDTO] = dfield(default_factory=list)
-    labels: dict[str, str] = dfield(default_factory=dict)
+    jlpt_kanji_levels: dict[str, int] = Field(default_factory=dict)
+    jlpt_grammar: list[JLPTGrammarDTO] = Field(default_factory=list)
+    sentences: list[SentenceDTO] = Field(default_factory=list)
+    labels: dict[str, str] = Field(default_factory=dict)
+
+    def has_entries(self) -> bool:
+        """
+        Report whether the result carries any dictionary entries
+
+        Returns:
+            True when at least one JMdict entry matched
+        """
+        return bool(self.entries)
+
+    def has_names(self) -> bool:
+        """
+        Report whether the result carries any proper names
+
+        Returns:
+            True when at least one JMnedict name matched
+        """
+        return bool(self.names)
+
+    def has_kanji(self) -> bool:
+        """
+        Report whether the result carries any kanji details
+
+        Returns:
+            True when at least one kanji profile is present
+        """
+        return bool(self.kanji)
+
+    def has_sentences(self) -> bool:
+        """
+        Report whether the result carries any example sentences
+
+        Returns:
+            True when at least one Tatoeba sentence matched
+        """
+        return bool(self.sentences)
 
     def has_jlpt(self) -> bool:
         """
@@ -781,3 +771,26 @@ class LookupResult(Serializable):
             True when a JLPT vocabulary entry or kanji level is present
         """
         return self.jlpt_vocab is not None or bool(self.jlpt_kanji_levels)
+
+
+KotobaseDTO: TypeAlias = (
+    GlossDTO
+    | SenseDTO
+    | KanjiFormDTO
+    | KanaFormDTO
+    | JMDictEntryDTO
+    | NameTranslationDTO
+    | JMNeDictEntryDTO
+    | KanjiDTO
+    | FuriganaDTO
+    | SentenceDTO
+    | JLPTVocabDTO
+    | JLPTKanjiDTO
+    | JLPTGrammarDTO
+    | RadicalDTO
+    | AudioDTO
+    | LookupResult
+)
+"""
+Represents any one of Kotobase's data transfer objects
+"""

--- a/kotobase/src/kotobase/db/repos.py
+++ b/kotobase/src/kotobase/db/repos.py
@@ -10,18 +10,33 @@ info: Session Management
     - Repositories never open their own session
     - The [`Unit Of Work`][kotobase.db.uow] owns one session and hands the
       same one to every repository it exposes
+
+info: Error Handling
+    - Every repository inherits from
+      [`KotobaseRepo`][kotobase.db.repos.KotobaseRepo], whose
+      `__init_subclass__` wraps each public method so an unexpected
+      `SQLAlchemy` failure surfaces as a
+      [`DatabaseError`][kotobase.exceptions.DatabaseError]
+
+    - Kotobase errors, such as a missing audio pack, pass through unchanged
 """
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+import functools
+from collections.abc import Callable, Sequence
+from typing import Any, ParamSpec, TypeVar
 
 from sqlalchemy import ColumnElement, func, select, text
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import OperationalError, SQLAlchemyError
 from sqlalchemy.orm import Session, selectinload
 
+from ..exceptions import (
+    AudioDatabaseNotFoundError,
+    DatabaseError,
+    KotobaseError,
+)
 from . import dtos
-from .connection import AudioDatabaseNotFoundError
 from .models import (
     Audio,
     Furigana,
@@ -46,266 +61,13 @@ from .models import (
     Tag,
 )
 
+# --- Typing Helpers ---
 
-class Repository:
-    """
-    Base class for a repository bound to a database session
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+_T = TypeVar("_T", bound=type)
 
-    Attributes:
-        session (Session): The session used for every query
-    """
-
-    def __init__(self, session: Session) -> None:
-        """
-        Binds the repository to a session
-
-        Args:
-            session (Session): The active session to query through
-        """
-        self.session = session
-
-
-_JMDICT_LOAD = (
-    selectinload(JMDictEntry.kanji),
-    selectinload(JMDictEntry.kana),
-    selectinload(JMDictEntry.senses).selectinload(JMDictSense.glosses),
-)
-"""
-Eager-loading configuration for `JMdict` entries
-"""
-
-
-_JMDICT_ORDER = (
-    JMDictEntry.is_common.desc(),
-    JMDictEntry.freq_rank.is_(None),
-    JMDictEntry.freq_rank,
-    JMDictEntry.id,
-)
-"""
-How `JMDict` entries should be ordered
-"""
-
-
-class JMDictRepo(Repository):
-    """
-    Repository that abstract queries for the JMdict tables
-    """
-
-    def by_id(self, entry_id: int) -> dtos.JMDictEntryDTO | None:
-        """
-        Fetches a single entry by its sequence number
-
-        Args:
-            entry_id (int): The JMdict sequence number
-
-        Returns:
-            The entry, or None when no entry has that id
-        """
-        entry = self.session.get(JMDictEntry, entry_id, options=_JMDICT_LOAD)
-        return dtos.JMDictEntryDTO.from_orm(entry) if entry else None
-
-    def _by_ids(self, ids: list[int]) -> list[dtos.JMDictEntryDTO]:
-        """
-        Fetches several entries by id, ordered by commonness, then frequency
-
-        Args:
-            ids (list[int]): The entry ids to fetch
-
-        Returns:
-            The matching entries as data transfer objects
-        """
-        if not ids:
-            return []
-        statement = (
-            select(JMDictEntry)
-            .where(JMDictEntry.id.in_(ids))
-            .options(*_JMDICT_LOAD)
-            .order_by(*_JMDICT_ORDER)
-        )
-        entries = self.session.scalars(statement).all()
-        return [dtos.JMDictEntryDTO.from_orm(entry) for entry in entries]
-
-    def search_form(
-        self,
-        form: str,
-        *,
-        wildcard: bool = False,
-        limit: int | None = 50,
-    ) -> list[dtos.JMDictEntryDTO]:
-        """
-        Searches entries by a written or reading form
-
-        Args:
-            form (str): The query form, where `*` and `%` act as wildcards when
-                `wildcard` is True
-            wildcard (bool): When True, treat the query as a `LIKE` pattern,
-                otherwise match it exactly
-            limit (int | None): Maximum entries to return, or None for no limit
-
-        Returns:
-            The matching entries as data transfer objects
-        """
-        kanji_match: ColumnElement[bool]
-        kana_match: ColumnElement[bool]
-        if wildcard:
-            pattern = form.replace("*", "%")
-            kanji_match = JMDictKanji.text.like(pattern)
-            kana_match = JMDictKana.text.like(pattern)
-        else:
-            kanji_match = JMDictKanji.text == form
-            kana_match = JMDictKana.text == form
-        statement = (
-            select(JMDictEntry)
-            .where(
-                JMDictEntry.kanji.any(kanji_match)
-                | JMDictEntry.kana.any(kana_match)
-            )
-            .options(*_JMDICT_LOAD)
-            .order_by(*_JMDICT_ORDER)
-            .limit(limit)
-        )
-        entries = self.session.scalars(statement).all()
-        return [dtos.JMDictEntryDTO.from_orm(entry) for entry in entries]
-
-    def search_gloss(
-        self,
-        query: str,
-        *,
-        limit: int = 50,
-    ) -> list[dtos.JMDictEntryDTO]:
-        """
-        Search entries by English meaning using full text search
-
-        Args:
-            query (str): The FTS5 match expression to run against glosses
-            limit (int): Maximum number of entries to return
-
-        Returns:
-            The matching entries as data transfer objects
-        """
-        rows = self.session.execute(
-            text(
-                "SELECT s.entry_id FROM gloss_fts f "
-                "JOIN jmdict_sense s ON s.id = f.sense_id "
-                "WHERE gloss_fts MATCH :query LIMIT :limit"
-            ),
-            {"query": query, "limit": limit},
-        )
-        unique: dict[int, None] = {}
-        for (entry_id,) in rows:
-            unique.setdefault(entry_id, None)
-        return self._by_ids(list(unique))
-
-
-# --- JMnedict ---
-_JMNEDICT_LOAD = (
-    selectinload(JMnedictEntry.kanji),
-    selectinload(JMnedictEntry.kana),
-    selectinload(JMnedictEntry.translations).selectinload(
-        JMnedictTranslation.glosses
-    ),
-)
-"""
-Eager-loading configuration for `JMNedict` entries
-"""
-
-
-class JMNeDictRepo(Repository):
-    """
-    Queries the JMnedict tables
-    """
-
-    def by_id(self, entry_id: int) -> dtos.JMNeDictEntryDTO | None:
-        """
-        Fetch a single name entry by its sequence number
-
-        Args:
-            entry_id (int): The JMnedict sequence number
-
-        Returns:
-            The entry, or None when no entry has that id
-        """
-        entry = self.session.get(
-            JMnedictEntry, entry_id, options=_JMNEDICT_LOAD
-        )
-        return dtos.JMNeDictEntryDTO.from_orm(entry) if entry else None
-
-    def search(
-        self,
-        form: str,
-        *,
-        wildcard: bool = False,
-        limit: int | None = 50,
-    ) -> list[dtos.JMNeDictEntryDTO]:
-        """
-        Search names by a written or reading form
-
-        Args:
-            form (str): The query form, where `*` and `%` act as wildcards when
-                `wildcard` is True
-            wildcard (bool): When True, treat the query as a `LIKE` pattern,
-                otherwise match it exactly
-            limit (int | None): Maximum entries to return, or None for no limit
-
-        Returns:
-            The matching names as data transfer objects
-        """
-        kanji_match: ColumnElement[bool]
-        kana_match: ColumnElement[bool]
-        if wildcard:
-            pattern = form.replace("*", "%")
-            kanji_match = JMnedictKanji.text.like(pattern)
-            kana_match = JMnedictKana.text.like(pattern)
-        else:
-            kanji_match = JMnedictKanji.text == form
-            kana_match = JMnedictKana.text == form
-        statement = (
-            select(JMnedictEntry)
-            .where(
-                JMnedictEntry.kanji.any(kanji_match)
-                | JMnedictEntry.kana.any(kana_match)
-            )
-            .options(*_JMNEDICT_LOAD)
-            .order_by(JMnedictEntry.id)
-            .limit(limit)
-        )
-        entries = self.session.scalars(statement).all()
-        return [dtos.JMNeDictEntryDTO.from_orm(entry) for entry in entries]
-
-    def browse_by_type(
-        self,
-        name_type: str,
-        *,
-        limit: int = 50,
-    ) -> list[dtos.JMNeDictEntryDTO]:
-        """
-        Browse names that carry a given name type
-
-        Args:
-            name_type (str): The name type code such as `place` or `surname`
-            limit (int): Maximum number of entries to return
-
-        Returns:
-            The matching names as data transfer objects
-        """
-        entry_ids = self.session.scalars(
-            select(JMnedictTranslation.entry_id)
-            .where(JMnedictTranslation.name_type.like(f'%"{name_type}"%'))
-            .distinct()
-            .limit(limit)
-        ).all()
-        if not entry_ids:
-            return []
-        entries = self.session.scalars(
-            select(JMnedictEntry)
-            .where(JMnedictEntry.id.in_(list(entry_ids)))
-            .options(*_JMNEDICT_LOAD)
-            .order_by(JMnedictEntry.id)
-        ).all()
-        return [dtos.JMNeDictEntryDTO.from_orm(entry) for entry in entries]
-
-
-# --- Kanji ---
+# --- Eager Loading Helpers ---
 _KANJI_LOAD = (
     selectinload(Kanji.readings),
     selectinload(Kanji.meanings),
@@ -319,6 +81,80 @@ _KANJI_LOAD = (
 """
 Eager-loading configuration for `kanji` entries
 """
+
+_JMDICT_LOAD = (
+    selectinload(JMDictEntry.kanji),
+    selectinload(JMDictEntry.kana),
+    selectinload(JMDictEntry.senses).selectinload(JMDictSense.glosses),
+)
+"""
+Eager-loading configuration for `JMdict` entries
+"""
+
+_JMNEDICT_LOAD = (
+    selectinload(JMnedictEntry.kanji),
+    selectinload(JMnedictEntry.kana),
+    selectinload(JMnedictEntry.translations).selectinload(
+        JMnedictTranslation.glosses
+    ),
+)
+"""
+Eager-loading configuration for `JMNedict` entries
+"""
+
+# --- Ordering Helpers ---
+
+_JMDICT_ORDER = (
+    JMDictEntry.is_common.desc(),
+    JMDictEntry.freq_rank.is_(None),
+    JMDictEntry.freq_rank,
+    JMDictEntry.id,
+)
+"""
+Defines the default sorting priority for JMDict vocabulary entries
+
+info: `Common` Entries
+    Kotobase classifies a `JMDict` entry's kanji / kana form as being
+    `common` when it contains any of the following priority codes in its
+    JMDict XML `<pri>` Tags
+
+    - `news1`
+    - `ichi1`
+    - `spec1`
+    - `spec2`
+    - `gai1`
+
+This ordering configuration ensures that search results are intuitive,
+relevant, and deterministic by applying a four-tiered sorting logic
+
+info: `1` - Commonality (`JMDictEntry.is_common.desc()`)
+   Prioritizes entry records marked as common over rare or archaic terms
+
+info: `2` - Null Frequency Handling (`JMDictEntry.freq_rank.is_(None)`)
+   - Acts as a data-integrity guard rail
+
+   - In `SQL`, boolean expressions evaluate to 0 (False) or 1 (True). By
+     sorting ascending, entries *with* frequency data (False/0) are grouped
+     ahead of entries *without* frequency data (True/1)
+
+   - This prevents `NULL` values from breaking or misaligning the subsequent
+     numerical sort
+
+info: `3` - Frequency Rank (`JMDictEntry.freq_rank`)
+   - Sorts entries numerically by their popularity rank
+
+   - Lower numbers represent higher real-world usage
+     (e.g. A rank of 50 appears before a rank of 5000)
+
+info: `4` -  Primary Key Determinism (`JMDictEntry.id`)
+   - Serves as the absolute tie-breaker using the entry's unique ID
+
+   - This guarantees a stable, identical sorting order across identical data
+     subsets, which is essential for consistent pagination and preventing
+     duplicate items across page loads
+"""
+
+# --- SVG Helpers ---
 
 _SVG_OPEN = (
     '<svg xmlns="http://www.w3.org/2000/svg"'
@@ -343,14 +179,401 @@ Closing of a renderable KanjiVG document, matching `_SVG_OPEN`
 """
 
 
+# --- Exception Handling Helpers ---
+
+
+def _wrap_sqlalchemy_error(method: Callable[_P, _R]) -> Callable[_P, _R]:
+    """
+    Decorates a repository method so a raised `SQLAlchemyError` becomes a
+    [`DatabaseError`][kotobase.exceptions.DatabaseError]
+
+    The returned wrapper calls `method` and lets its result pass through. A
+    [`KotobaseError`][kotobase.exceptions.KotobaseError] is re-raised unchanged
+    so callers can still distinguish it. Any other `SQLAlchemyError` is
+    re-raised as a `DatabaseError` whose message names the failing method via
+    its `__qualname__` and chains the original exception with `from`.
+    The wrapper keeps the wrapped method's identity through `functools.wraps`
+
+    Args:
+        method (Callable[_P, _R]): The repository method to wrap
+
+    Returns:
+        The wrapped method, with the same signature and return type
+    """
+
+    @functools.wraps(method)
+    def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+        try:
+            return method(*args, **kwargs)
+        except KotobaseError:
+            raise
+        except SQLAlchemyError as exc:
+            raise DatabaseError(
+                f"Database Query Failed In '{method.__qualname__}' : {exc}"
+            ) from exc
+
+    return wrapper
+
+
+# --- Base Repository Class ---
+
+
+class KotobaseRepo:
+    """
+    Base class for a repository that runs queries through one shared session
+
+    info: Error Handling
+        - Subclassing also installs the central error wrapping
+
+        - Every public method a subclass defines is replaced with a version
+          that converts a raised `SQLAlchemyError` into a
+          [`DatabaseError`][kotobase.exceptions.DatabaseError], so individual
+          methods only document their own non-`SQLAlchemy` raises
+
+    Attributes:
+        session (Session): The session, owned by the unit of work, that every
+            query on this repository runs through
+    """
+
+    def __init__(self, session: Session) -> None:
+        """
+        Store the session this repository runs all of its queries through
+
+        The session is not opened or owned here, it is supplied by the unit of
+        work and shared with the other repositories
+
+        Args:
+            session (Session): The active session to query through
+        """
+        self.session = session
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        """
+        Wrap each public method the subclass defines with the `SQLAlchemy`
+        error handler
+
+        Iterates the subclass's own `vars`, and for every callable, non-`_`
+        attribute, replaces it with the result of `_wrap_sqlalchemy_error`, so
+        a raised `SQLAlchemyError` surfaces as a
+        [`DatabaseError`][kotobase.exceptions.DatabaseError] while a
+        [`KotobaseError`][kotobase.exceptions.KotobaseError] passes through
+
+        Args:
+            **kwargs (Any): Extra arguments forwarded to the base hook
+        """
+        super().__init_subclass__(**kwargs)
+
+        for name, attr in list(vars(cls).items()):
+            if not name.startswith("_") and callable(attr):
+                setattr(cls, name, _wrap_sqlalchemy_error(attr))
+
+
+class JMDictRepo(KotobaseRepo):
+    """
+    Repository that abstracts queries over the `JMdict` tables
+
+    Looks up entries by sequence number, by written or reading form against the
+    normalized `jmdict_kanji` / `jmdict_kana` tables, and by English meaning
+    through the `gloss_fts` full-text index. Every method eagerly loads kanji
+    forms, kana forms and senses with their glosses (`_JMDICT_LOAD`) and
+    returns [`JMDictEntryDTO`][kotobase.db.dtos.JMDictEntryDTO] objects built
+    with `model_validate`
+    """
+
+    def by_id(self, entry_id: int) -> dtos.JMDictEntryDTO | None:
+        """
+        Fetch one entry by its `JMdict` sequence number
+
+        Loads the row through `Session.get` with `_JMDICT_LOAD` eager loading
+        of its kanji forms, kana forms and senses with glosses, then validates
+        it into a [`JMDictEntryDTO`][kotobase.db.dtos.JMDictEntryDTO]
+
+        Args:
+            entry_id (int): The `JMdict` sequence number (primary key)
+
+        Returns:
+            The entry as a DTO, or `None` when no row has that id
+        """
+        entry = self.session.get(JMDictEntry, entry_id, options=_JMDICT_LOAD)
+        return dtos.JMDictEntryDTO.model_validate(entry) if entry else None
+
+    def _by_ids(self, ids: list[int]) -> list[dtos.JMDictEntryDTO]:
+        """
+        Fetch several entries by id in the canonical `JMdict` order
+
+        Selects every [`JMDictEntry`][kotobase.db.models.JMDictEntry] whose id
+        is `IN` the given list, eager-loading with `_JMDICT_LOAD` and ordering
+        by `_JMDCIT_ORDER`
+        Args:
+            ids (list[int]): The entry ids to fetch
+
+        Returns:
+            The matching entries as DTOs ordered by commonness then frequency,
+                or `[]` when `ids` is empty
+        """
+        if not ids:
+            return []
+        statement = (
+            select(JMDictEntry)
+            .where(JMDictEntry.id.in_(ids))
+            .options(*_JMDICT_LOAD)
+            .order_by(*_JMDICT_ORDER)
+        )
+        entries = self.session.scalars(statement).all()
+        return [dtos.JMDictEntryDTO.model_validate(entry) for entry in entries]
+
+    def search_form(
+        self,
+        form: str,
+        *,
+        wildcard: bool = False,
+        limit: int | None = 50,
+    ) -> list[dtos.JMDictEntryDTO]:
+        """
+        Search entries by a written or reading form
+
+        Matches `form` against `JMDictKanji.text` or `JMDictKana.text` using
+        `EXISTS` (`relationship.any`). By default the comparison is exact. When
+        `wildcard` is True, `*` is translated to `%` and the form is matched as
+        a SQL `LIKE` pattern. Results are eager-loaded with
+        `_JMDICT_LOAD`, ordered by `_JMDICT_ORDER`, and capped at `limit`
+
+        Args:
+            form (str): The query form, where `*` and `%` act as wildcards when
+                `wildcard` is True
+            wildcard (bool): When True, treat the query as a `LIKE` pattern,
+                otherwise match it exactly
+            limit (int | None): Maximum entries to return, or `None` for no
+                limit
+
+        Returns:
+            The matching entries as DTOs, or `[]` when none match
+        """
+        kanji_match: ColumnElement[bool]
+        kana_match: ColumnElement[bool]
+        if wildcard:
+            pattern = form.replace("*", "%")
+            kanji_match = JMDictKanji.text.like(pattern)
+            kana_match = JMDictKana.text.like(pattern)
+        else:
+            kanji_match = JMDictKanji.text == form
+            kana_match = JMDictKana.text == form
+        statement = (
+            select(JMDictEntry)
+            .where(
+                JMDictEntry.kanji.any(kanji_match)
+                | JMDictEntry.kana.any(kana_match)
+            )
+            .options(*_JMDICT_LOAD)
+            .order_by(*_JMDICT_ORDER)
+            .limit(limit)
+        )
+        entries = self.session.scalars(statement).all()
+        return [dtos.JMDictEntryDTO.model_validate(entry) for entry in entries]
+
+    def search_gloss(
+        self,
+        query: str,
+        *,
+        limit: int | None = 50,
+    ) -> list[dtos.JMDictEntryDTO]:
+        """
+        Search entries by English meaning through the `gloss_fts` index
+
+        Runs a raw `FTS5` query that matches `query` against the `gloss_fts`
+        virtual table (`gloss_fts MATCH :query`), joined to `jmdict_sense` to
+        recover each matching sense's `entry_id`, capped at `limit` rows. The
+        entry ids are de-duplicated while preserving first-seen order, then
+        re-fetched and ordered through `_by_ids`, so the final ordering is the
+        canonical commonness/frequency order rather than relevance
+
+        Args:
+            query (str): The `FTS5` match expression to run against glosses
+            limit (int | None): Maximum number of `gloss_fts` rows to scan
+
+        Returns:
+            The matching entries as DTOs, or `[]` when none match
+        """
+        rows = self.session.execute(
+            text(
+                "SELECT s.entry_id FROM gloss_fts f "
+                "JOIN jmdict_sense s ON s.id = f.sense_id "
+                "WHERE gloss_fts MATCH :query LIMIT :limit"
+            ),
+            {"query": query, "limit": -1 if limit is None else limit},
+        )
+        unique: dict[int, None] = {}
+        for (entry_id,) in rows:
+            unique.setdefault(entry_id, None)
+        return self._by_ids(list(unique))
+
+    def resolve_reference(self, ref: str) -> list[dtos.JMDictEntryDTO]:
+        """
+        Resolve a cross-reference or antonym code to its entries
+
+        `JMdict` `xref` and `antonym` codes are `・`-separated into a leading
+        form and an optional disambiguating reading and sense number. This
+        takes the part before the first `・`, strips it, and when it is
+        non-empty looks it up exactly through `search_form` with no limit (the
+        reading and sense number are ignored). An empty leading form returns
+        `[]` without querying
+
+        Args:
+            ref (str): The cross-reference or antonym code to resolve
+
+        Returns:
+            The entries the leading form points to, or `[]` when the form is
+                empty or nothing matches
+        """
+        form = ref.split("・")[0].strip()
+        if not form:
+            return []
+        return self.search_form(form, limit=None)
+
+
+# --- JMnedict ---
+
+
+class JMNeDictRepo(KotobaseRepo):
+    """
+    Repository that abstracts queries over the `JMnedict` proper-name tables
+
+    Looks up names by sequence number, by written or reading form against the
+    normalized `jmnedict_kanji` / `jmnedict_kana` tables, and by name type.
+    Every method eagerly loads kanji forms, kana forms and translation blocks
+    with their glosses (`_JMNEDICT_LOAD`) and returns
+    [`JMNeDictEntryDTO`][kotobase.db.dtos.JMNeDictEntryDTO] objects built with
+    `model_validate`
+    """
+
+    def by_id(self, entry_id: int) -> dtos.JMNeDictEntryDTO | None:
+        """
+        Fetch one name entry by its `JMnedict` sequence number
+
+        Loads the row through `Session.get` with `_JMNEDICT_LOAD` eager loading
+        of its kanji forms, kana forms and translation blocks with glosses,
+        then validates it into a
+        [`JMNeDictEntryDTO`][kotobase.db.dtos.JMNeDictEntryDTO]
+
+        Args:
+            entry_id (int): The `JMnedict` sequence number (primary key)
+
+        Returns:
+            The name entry as a DTO, or `None` when no row has that id
+        """
+        entry = self.session.get(
+            JMnedictEntry, entry_id, options=_JMNEDICT_LOAD
+        )
+        return dtos.JMNeDictEntryDTO.model_validate(entry) if entry else None
+
+    def search(
+        self,
+        form: str,
+        *,
+        wildcard: bool = False,
+        limit: int | None = 50,
+    ) -> list[dtos.JMNeDictEntryDTO]:
+        """
+        Search names by a written or reading form
+
+        Matches `form` against `JMnedictKanji.text` or `JMnedictKana.text`
+        with `EXISTS` (`relationship.any`). By default the comparison is exact.
+        When `wildcard` is True, `*` is translated to `%` and the form
+        is matched as a SQL `LIKE` pattern. Results are eager-loaded with
+        `_JMNEDICT_LOAD`, ordered by ascending `JMnedictEntry.id` and capped at
+        `limit`
+
+        Args:
+            form (str): The query form, where `*` and `%` act as wildcards when
+                `wildcard` is True
+            wildcard (bool): When True, treat the query as a `LIKE` pattern,
+                otherwise match it exactly
+            limit (int | None): Maximum entries to return, or `None` for no
+                limit
+
+        Returns:
+            The matching names as DTOs ordered by id, or `[]` when none match
+        """
+        kanji_match: ColumnElement[bool]
+        kana_match: ColumnElement[bool]
+        if wildcard:
+            pattern = form.replace("*", "%")
+            kanji_match = JMnedictKanji.text.like(pattern)
+            kana_match = JMnedictKana.text.like(pattern)
+        else:
+            kanji_match = JMnedictKanji.text == form
+            kana_match = JMnedictKana.text == form
+        statement = (
+            select(JMnedictEntry)
+            .where(
+                JMnedictEntry.kanji.any(kanji_match)
+                | JMnedictEntry.kana.any(kana_match)
+            )
+            .options(*_JMNEDICT_LOAD)
+            .order_by(JMnedictEntry.id)
+            .limit(limit)
+        )
+        entries = self.session.scalars(statement).all()
+        return [
+            dtos.JMNeDictEntryDTO.model_validate(entry) for entry in entries
+        ]
+
+    def browse_by_type(
+        self,
+        name_type: str,
+        *,
+        limit: int | None = 50,
+    ) -> list[dtos.JMNeDictEntryDTO]:
+        """
+        Browse names that carry a given name type
+
+        The `name_type` codes of a block are stored as a JSON list in
+        `JMnedictTranslation.name_type`, so this matches the quoted code as a
+        substring (`LIKE '%"<name_type>"%'`) to find translation blocks of that
+        type, collecting up to `limit` distinct owning `entry_id` values. Those
+        entries are then re-fetched eager-loaded with `_JMNEDICT_LOAD` and
+        ordered by ascending id. When no block matches, returns `[]` without
+        the second query
+
+        Args:
+            name_type (str): The name type code such as `place` or `surname`
+            limit (int | None): Maximum number of distinct entry ids to collect
+
+        Returns:
+            The matching names as DTOs ordered by id, or `[]` when none match
+        """
+        entry_ids = self.session.scalars(
+            select(JMnedictTranslation.entry_id)
+            .where(JMnedictTranslation.name_type.like(f'%"{name_type}"%'))
+            .distinct()
+            .limit(limit)
+        ).all()
+        if not entry_ids:
+            return []
+        entries = self.session.scalars(
+            select(JMnedictEntry)
+            .where(JMnedictEntry.id.in_(list(entry_ids)))
+            .options(*_JMNEDICT_LOAD)
+            .order_by(JMnedictEntry.id)
+        ).all()
+        return [
+            dtos.JMNeDictEntryDTO.model_validate(entry) for entry in entries
+        ]
+
+
+# --- Kanji ---
+
+
 def _svg_document(fragment: str) -> str:
     """
     Wrap a raw KanjiVG `<kanji>` fragment into a renderable SVG document
 
     The stored markup is the raw `<kanji>` element, which is not an `<svg>` and
-    carries no namespace or styling, so a browser renders nothing from it. The
-    inner stroke groups and their `kvg` metadata are kept verbatim while an
-    `<svg>` root supplies the SVG namespace, the `109` canvas view box and a
+    carries no namespace or styling, so a browser renders nothing from it. This
+    slices out the element's inner content, the stroke `<g>` groups and their
+    `kvg` metadata, between the end of the opening `<kanji ...>` tag (the first
+    `>`) and the final `</kanji>`, then splices it between `_SVG_OPEN` and
+    `_SVG_CLOSE`, which add the SVG namespace, the 109 canvas view box and a
     default black stroke style that any consumer stylesheet can override
 
     Args:
@@ -364,20 +587,100 @@ def _svg_document(fragment: str) -> str:
     return f"{_SVG_OPEN}{fragment[start:end]}{_SVG_CLOSE}"
 
 
-class KanjiRepo(Repository):
+def _kanji_payload(
+    kanji: Kanji,
+    radicals: Sequence[str],
+    jlpt_tanos: int | None,
+) -> dict[str, Any]:
     """
-    Queries KanjiDic2 together with radical and JLPT data
+    Assemble a `KanjiDTO`-ready mapping from a loaded kanji ORM row
+
+    Flattens the kanji's relationships into the shapes
+    [`KanjiDTO`][kotobase.db.dtos.KanjiDTO] expects, since they cannot be
+    mapped field-for-field
+
+    info: Formatting
+
+    - The `readings` relationship is split by `type` into `onyomi` (`ja_on`),
+      `kunyomi` (`ja_kun`), `pinyin` and `korean` (`korean_r` / `korean_h`)
+
+    - `meanings` is filtered to English (`lang == "en"`)
+
+    - `query_codes` is grouped into a `type -> [value]` dict while
+      `dic_refs` and `codepoints` become `type -> value` dicts
+
+    - `variants` keeps its `type` / `value` pairs
+
+    - `has_stroke_order` is True when the `strokes` relationship is present
+
+    - The `radicals` and `jlpt_tanos` values, which are not kanji
+      relationships, are passed in by the caller and overlaid
+
+    Args:
+        kanji (Kanji): The kanji with its readings, meanings, nanori, dic refs,
+            query codes, variants, codepoints and stroke data loaded
+        radicals (Sequence[str]): Radical components, passed in since they are
+            not a direct relationship of the kanji
+        jlpt_tanos (int | None): The Tanos JLPT level when known
+
+    Returns:
+        A mapping with the derived list and dict fields `KanjiDTO` expects
+    """
+    query_codes: dict[str, list[str]] = {}
+    for code in kanji.query_codes:
+        query_codes.setdefault(code.type, []).append(code.value)
+    korean = ("korean_r", "korean_h")
+    return {
+        "literal": kanji.literal,
+        "grade": kanji.grade,
+        "stroke_count": kanji.stroke_count,
+        "freq": kanji.freq,
+        "jlpt_old": kanji.jlpt_old,
+        "jlpt_tanos": jlpt_tanos,
+        "onyomi": [r.value for r in kanji.readings if r.type == "ja_on"],
+        "kunyomi": [r.value for r in kanji.readings if r.type == "ja_kun"],
+        "nanori": [n.value for n in kanji.nanori],
+        "pinyin": [r.value for r in kanji.readings if r.type == "pinyin"],
+        "korean": [r.value for r in kanji.readings if r.type in korean],
+        "meanings": [m.value for m in kanji.meanings if m.lang == "en"],
+        "radicals": list(radicals),
+        "dic_refs": {ref.type: ref.value for ref in kanji.dic_refs},
+        "query_codes": query_codes,
+        "codepoints": {cp.type: cp.value for cp in kanji.codepoints},
+        "variants": [
+            {"type": v.type, "value": v.value} for v in kanji.variants
+        ],
+        "has_stroke_order": kanji.strokes is not None,
+    }
+
+
+class KanjiRepo(KotobaseRepo):
+    """
+    Repository that abstracts `KanjiDic2` lookups enriched with extras
+
+    Reads kanji from the `kanji` table, eager-loading every per-character
+    relationship, and joins in two pieces that
+    are not kanji relationships, the `KRADFILE` radical components and the
+    Tanos JLPT level, which are injected through `_kanji_payload` when
+    validating each [`KanjiDTO`][kotobase.db.dtos.KanjiDTO]. Also serves
+    stroke-order SVG and lookups by SKIP code or scalar attribute
     """
 
     def _radicals(self, literals: Sequence[str]) -> dict[str, list[str]]:
         """
-        Fetch radical components grouped by kanji
+        Fetch the `KRADFILE` radical components grouped by kanji
+
+        Selects `(literal, radical)` rows from
+        [`KanjiRadical`][kotobase.db.models.KanjiRadical] whose `literal` is
+        `IN` the given set and groups the radicals under each kanji. An empty
+        `literals` argument returns `{}` without a query
 
         Args:
             literals (Sequence[str]): The kanji to look up
 
         Returns:
-            A mapping of kanji to its radical components
+            A mapping of each kanji to its list of radical components, omitting
+                kanji that have no rows
         """
         grouped: dict[str, list[str]] = {}
         if not literals:
@@ -395,11 +698,16 @@ class KanjiRepo(Repository):
         """
         Fetch Tanos JLPT levels keyed by kanji
 
+        Selects `(kanji, level)` rows from
+        [`JlptKanji`][kotobase.db.models.JlptKanji] whose `kanji` is `IN` the
+        given set. An empty `literals` argument returns `{}` without a query
+
         Args:
             literals (Sequence[str]): The kanji to look up
 
         Returns:
-            A mapping of kanji to its JLPT level
+            A mapping of each listed kanji to its Tanos JLPT level, omitting
+                kanji that are not in the Tanos list
         """
         if not literals:
             return {}
@@ -412,26 +720,40 @@ class KanjiRepo(Repository):
 
     def by_literal(self, literal: str) -> dtos.KanjiDTO | None:
         """
-        Fetch a single kanji with its full profile
+        Fetch one kanji with its full profile
+
+        Thin wrapper that delegates to `bulk_fetch` with a single literal and
+        unwraps the result
 
         Args:
             literal (str): The kanji character
 
         Returns:
-            The kanji, or None when it is not in the database
+            The kanji as a [`KanjiDTO`][kotobase.db.dtos.KanjiDTO], or `None`
+                when the character is not in the `kanji` table
         """
         results = self.bulk_fetch([literal])
         return results[0] if results else None
 
     def bulk_fetch(self, literals: Sequence[str]) -> list[dtos.KanjiDTO]:
         """
-        Fetch several kanji at once preserving input order
+        Fetch several kanji at once, preserving first-seen input order
+
+        De-duplicates `literals` while keeping order, then selects the matching
+        [`Kanji`][kotobase.db.models.Kanji] rows (`literal IN ...`)
+        eager-loaded with `_KANJI_LOAD`, and gathers their radical components
+        and Tanos JLPT levels through `_radicals` and `_jlpt_levels`. Each
+        found kanji is built into a [`KanjiDTO`][kotobase.db.dtos.KanjiDTO] via
+        `_kanji_payload`, which injects that kanji's radicals and JLPT level,
+        and the results are emitted in input order. Requested literals with no
+        `kanji` row are skipped, so the result may be shorter than the input.
+        An empty input returns `[]` without a query
 
         Args:
             literals (Sequence[str]): The kanji characters to fetch
 
         Returns:
-            The matching kanji as data transfer objects
+            The matching kanji as DTOs in input order, or `[]` when none match
         """
         ordered = list(dict.fromkeys(literals))
         if not ordered:
@@ -449,44 +771,58 @@ class KanjiRepo(Repository):
             kanji = by_literal.get(literal)
             if kanji is not None:
                 result.append(
-                    dtos.KanjiDTO.from_orm(
-                        kanji,
-                        radicals=radicals.get(literal, []),
-                        jlpt_tanos=jlpt.get(literal),
+                    dtos.KanjiDTO.model_validate(
+                        _kanji_payload(
+                            kanji,
+                            radicals.get(literal, []),
+                            jlpt.get(literal),
+                        )
                     )
                 )
         return result
 
     def stroke_svg(self, literal: str, *, raw: bool = False) -> str | None:
         """
-        Fetch a kanji's stroke order as SVG
+        Fetch a kanji's KanjiVG stroke order as SVG
 
-        By default this returns a self-contained, browser renderable SVG
-        document. Pass `raw` to get the original KanjiVG `<kanji>` fragment
-        instead, which has no `<svg>` root or styling
+        Loads the [`KanjiStrokes`][kotobase.db.models.KanjiStrokes] row by its
+        `literal` primary key. By default the stored KanjiVG `<kanji>` markup
+        is wrapped through `_svg_document` into a self-contained, browser
+        renderable `<svg>` document. Pass `raw` to get that stored `<kanji>`
+        fragment verbatim instead, which has no `<svg>` root or styling
 
         Args:
             literal (str): The kanji character
             raw (bool): When True, return the raw KanjiVG fragment unwrapped
 
         Returns:
-            The stroke order SVG, or None when no stroke data exists
+            The stroke order SVG, or `None` when the kanji has no stroke row
         """
         row = self.session.get(KanjiStrokes, literal)
         if row is None:
             return None
         return row.svg if raw else _svg_document(row.svg)
 
-    def by_skip(self, code: str, *, limit: int = 100) -> list[dtos.KanjiDTO]:
+    def by_skip(
+        self,
+        code: str,
+        *,
+        limit: int | None = 100,
+    ) -> list[dtos.KanjiDTO]:
         """
         Find kanji with a given SKIP query code
 
+        Selects up to `limit` `literal` values from
+        [`KanjiQueryCode`][kotobase.db.models.KanjiQueryCode] where `type` is
+        `skip` and `value` equals `code` exactly, then re-fetches their full
+        profiles through `bulk_fetch`
+
         Args:
             code (str): The SKIP code such as `1-4-3`
-            limit (int): Maximum number of kanji to return
+            limit (int | None): Maximum number of matching literals to collect
 
         Returns:
-            The matching kanji as data transfer objects
+            The matching kanji as DTOs, or `[]` when none carry the code
         """
         literals = self.session.scalars(
             select(KanjiQueryCode.literal)
@@ -505,20 +841,36 @@ class KanjiRepo(Repository):
         grade: int | None = None,
         freq_max: int | None = None,
         jlpt: int | None = None,
-        limit: int = 100,
+        limit: int | None = 100,
     ) -> list[dtos.KanjiDTO]:
         """
         Search kanji by scalar attributes
 
+        Builds a `select` over `Kanji.literal`, adding a filter for each
+        non-`None` argument. The literals are ordered with kanji
+        that have a `freq` ahead of those without, then by ascending `freq`,
+        then by character, capped at `limit`, and re-fetched as full profiles
+        through `bulk_fetch`
+
+        info: Filters
+            - `stroke_count` and `grade` match exactly
+            - `freq_max` keeps only kanji whose `freq` is set and `<= freq_max`
+            - `jlpt` restricts to literals present in
+            [`JlptKanji`][kotobase.db.models.JlptKanji] at that level
+              (subquery)
+
+            - Omitted arguments add no filter
+
         Args:
-            stroke_count (int | None): Required stroke count
-            grade (int | None): Required school grade
+            stroke_count (int | None): Required exact stroke count
+            grade (int | None): Required exact school grade
             freq_max (int | None): Maximum newspaper frequency rank
             jlpt (int | None): Required Tanos JLPT level
-            limit (int): Maximum number of kanji to return
+            limit (int | None): Maximum number of matching literals to collect
 
         Returns:
-            The matching kanji, ordered by frequency then character
+            The matching kanji as DTOs, ordered by frequency then character, or
+                `[]` when none match
         """
         statement = select(Kanji.literal)
         if stroke_count is not None:
@@ -543,47 +895,77 @@ class KanjiRepo(Repository):
 
 
 # --- Radicals ---
-class RadicalRepo(Repository):
+class RadicalRepo(KotobaseRepo):
     """
-    Queries radical data and performs radical search
+    Repository for the `RADKFILE` / `KRADFILE` radical decomposition data
+
+    Lists the `RADKFILE` search radicals, reads a kanji's radical components,
+    and performs reverse radical search, finding the kanji that contain a
+    chosen set of radicals
     """
 
     def list_radicals(self) -> list[dtos.RadicalDTO]:
         """
-        List every search radical with its stroke count
+        List every `RADKFILE` search radical with its stroke count
+
+        Selects all [`Radical`][kotobase.db.models.Radical] rows ordered by
+        ascending `stroke_count` then radical character, and validates each
+        into a [`RadicalDTO`][kotobase.db.dtos.RadicalDTO]
 
         Returns:
-            The radicals ordered by stroke count then character
+            Every search radical as a DTO, ordered by stroke count then
+                character
         """
         rows = self.session.scalars(
             select(Radical).order_by(Radical.stroke_count, Radical.radical)
         ).all()
-        return [dtos.RadicalDTO.from_orm(row) for row in rows]
+        return [dtos.RadicalDTO.model_validate(row) for row in rows]
 
     def radicals_of(self, literal: str) -> list[str]:
         """
-        List the radical components of a kanji
+        List the `KRADFILE` radical components of one kanji
+
+        Selects the `radical` column from
+        [`KanjiRadical`][kotobase.db.models.KanjiRadical] for rows whose
+        `literal` equals the kanji exactly, in primary-key order
 
         Args:
             literal (str): The kanji character
 
         Returns:
-            The radical components contained in the kanji
+            The radical components contained in the kanji, or `[]` when the
+                kanji has no decomposition
         """
         rows = self.session.execute(
             select(KanjiRadical.radical).where(KanjiRadical.literal == literal)
         )
         return [row.radical for row in rows]
 
-    def kanji_by_radicals(self, radicals: Sequence[str]) -> list[str]:
+    def kanji_by_radicals(
+        self,
+        radicals: Sequence[str],
+        *,
+        match: str = "all",
+    ) -> list[str]:
         """
-        Find kanji that contain every one of the given radicals
+        Find kanji that contain the given radicals (reverse radical search)
+
+        De-duplicates `radicals`, then groups
+        [`KanjiRadical`][kotobase.db.models.KanjiRadical] rows whose `radical`
+        is `IN` that set by `literal`. With `match="all"` a `HAVING` clause
+        keeps only kanji whose distinct matched-radical count equals the number
+        of requested radicals, so every radical is required (intersection). Any
+        other `match` value (such as `"any"`) drops the `HAVING` clause, so a
+        kanji that contains at least one of the radicals matches (union). An
+        empty `radicals` argument returns `[]` without a query
 
         Args:
-            radicals (Sequence[str]): The radical components to require
+            radicals (Sequence[str]): The radical components to match against
+            match (str): `all` to require every radical (intersection), or
+                `any` to match kanji that contain at least one (union)
 
         Returns:
-            The kanji that contain all of the radicals
+            The matching kanji literals, or `[]` when none match
         """
         wanted = list(dict.fromkeys(radicals))
         if not wanted:
@@ -592,17 +974,18 @@ class RadicalRepo(Repository):
             select(KanjiRadical.literal)
             .where(KanjiRadical.radical.in_(wanted))
             .group_by(KanjiRadical.literal)
-            .having(
+        )
+        if match == "all":
+            statement = statement.having(
                 func.count(func.distinct(KanjiRadical.radical)) == len(wanted)
             )
-        )
         return [literal for (literal,) in self.session.execute(statement)]
 
 
 # --- Furigana ---
-class FuriganaRepo(Repository):
+class FuriganaRepo(KotobaseRepo):
     """
-    Queries furigana segmentation
+    Repository for `JmdictFurigana` spelling-to-reading segmentation
     """
 
     def for_text(
@@ -611,47 +994,67 @@ class FuriganaRepo(Repository):
         reading: str | None = None,
     ) -> list[dtos.FuriganaDTO]:
         """
-        Fetch furigana for a written form
+        Fetch furigana segmentations for a written form
+
+        Selects [`Furigana`][kotobase.db.models.Furigana] rows whose `text`
+        equals `text_value` exactly. When `reading` is given it is added as a
+        second exact-match filter on `Furigana.reading`, narrowing to the one
+        spelling/reading pair (which is unique). Each row is validated into a
+        [`FuriganaDTO`][kotobase.db.dtos.FuriganaDTO]
 
         Args:
             text_value (str): The written spelling to look up
             reading (str | None): A specific reading to narrow the match
 
         Returns:
-            The matching furigana segmentations
+            The matching furigana segmentations as DTOs, or `[]` when none
+                match
         """
         statement = select(Furigana).where(Furigana.text == text_value)
         if reading is not None:
             statement = statement.where(Furigana.reading == reading)
         rows = self.session.scalars(statement).all()
-        return [dtos.FuriganaDTO.from_orm(row) for row in rows]
+        return [dtos.FuriganaDTO.model_validate(row) for row in rows]
 
 
 # --- Sentences ---
-class SentenceRepo(Repository):
+class SentenceRepo(KotobaseRepo):
     """
-    Queries Tatoeba example sentences and their translations
+    Repository for `Tatoeba` example sentences and their translations
     """
 
     def search_containing(
         self,
         query: str,
         *,
-        limit: int = 20,
+        limit: int | None = 20,
         wildcard: bool = False,
     ) -> list[dtos.SentenceDTO]:
         """
-        Find Japanese sentences containing the query text
+        Find Japanese sentences containing the query text, with translations
+
+        Selects up to `limit` [`Sentence`][kotobase.db.models.Sentence] rows
+        where `lang` is `jpn` and `text` matches a SQL `LIKE` pattern, ordered
+        by ascending id. By default the query is wrapped as `%query%` substring
+        containment. When `wildcard` is True, `*` is translated to `%` and the
+        query is used as the `LIKE` pattern directly. For the matched sentences
+        it then resolves translations by joining
+        [`SentenceLink`][kotobase.db.models.SentenceLink] (whose `source_id` is
+        the Japanese sentence) to the target `Sentence.text`, grouping the
+        translation texts per source id. Each sentence is validated into a
+        [`SentenceDTO`][kotobase.db.dtos.SentenceDTO] with its translations
+        injected through the validation `context`
 
         Args:
             query (str): The text to search for, where `*` and `%` act as
                 wildcards when `wildcard` is True
-            limit (int): Maximum number of sentences to return
+            limit (int | None): Maximum number of sentences to return
             wildcard (bool): When True, treat the query as a `LIKE` pattern,
-                otherwise match it as a substring
+                otherwise match it as a `%query%` substring
 
         Returns:
-            The matching sentences with any aligned translations
+            The matching sentences as DTOs with their aligned translations, or
+                `[]` when none match
         """
         pattern = query.replace("*", "%") if wildcard else f"%{query}%"
         sentences = self.session.scalars(
@@ -671,46 +1074,60 @@ class SentenceRepo(Repository):
             for source_id, sentence_text in rows:
                 translations.setdefault(source_id, []).append(sentence_text)
         return [
-            dtos.SentenceDTO.from_orm(
+            dtos.SentenceDTO.model_validate(
                 sentence,
-                translations=translations.get(sentence.id, []),
+                context={"translations": translations.get(sentence.id, [])},
             )
             for sentence in sentences
         ]
 
 
 # --- JLPT ---
-class JLPTRepo(Repository):
+class JLPTRepo(KotobaseRepo):
     """
-    Queries the Tanos JLPT lists
+    Repository for the Tanos JLPT vocabulary, kanji and grammar lists
+
+    Resolves a word or kanji to its JLPT level, searches grammar points by
+    substring, and returns full per-level study lists. Each method validates
+    rows into the matching JLPT DTO
     """
 
     def vocab_by_word(self, word: str) -> dtos.JLPTVocabDTO | None:
         """
-        Find the JLPT vocabulary entry for a word
+        Find the JLPT vocabulary entry for a word or reading
+
+        Selects the first [`JlptVocab`][kotobase.db.models.JlptVocab] row whose
+        `word` or `reading` equals `word` exactly (`LIMIT 1`), and validates it
+        into a [`JLPTVocabDTO`][kotobase.db.dtos.JLPTVocabDTO]
 
         Args:
             word (str): The headword or reading to look up
 
         Returns:
-            The vocabulary entry, or None when the word is not listed
+            The vocabulary entry as a DTO, or `None` when the word is not
+                listed
         """
         row = self.session.scalars(
             select(JlptVocab)
             .where((JlptVocab.word == word) | (JlptVocab.reading == word))
             .limit(1)
         ).first()
-        return dtos.JLPTVocabDTO.from_orm(row) if row else None
+        return dtos.JLPTVocabDTO.model_validate(row) if row else None
 
     def kanji_levels(self, literals: Sequence[str]) -> dict[str, int]:
         """
-        Map each given kanji to its JLPT level
+        Map each given kanji to its Tanos JLPT level
+
+        De-duplicates `literals`, then selects `(kanji, level)` from
+        [`JlptKanji`][kotobase.db.models.JlptKanji] where `kanji` is `IN` that
+        set. An empty input returns `{}` without a query
 
         Args:
             literals (Sequence[str]): The kanji to look up
 
         Returns:
-            A mapping of kanji to JLPT level for those that are listed
+            A mapping of each listed kanji to its JLPT level, omitting kanji
+                not in the Tanos list
         """
         wanted = list(dict.fromkeys(literals))
         if not wanted:
@@ -726,17 +1143,24 @@ class JLPTRepo(Repository):
         self,
         query: str,
         *,
-        limit: int = 20,
+        limit: int | None = 20,
     ) -> list[dtos.JLPTGrammarDTO]:
         """
         Find JLPT grammar points whose text contains the query
 
+        Selects up to `limit` [`JlptGrammar`][kotobase.db.models.JlptGrammar]
+        rows whose `grammar` contains `query` as a substring
+        (`LIKE '%query%'`), ordered by descending `level` (so N1 grammar comes
+        before N5), and validates each into a
+        [`JLPTGrammarDTO`][kotobase.db.dtos.JLPTGrammarDTO]
+
         Args:
             query (str): The substring to search for in grammar points
-            limit (int): Maximum number of grammar points to return
+            limit (int | None): Maximum number of grammar points to return
 
         Returns:
-            The matching grammar points as data transfer objects
+            The matching grammar points as DTOs ordered by descending level, or
+                `[]` when none match
         """
         rows = self.session.scalars(
             select(JlptGrammar)
@@ -744,90 +1168,117 @@ class JLPTRepo(Repository):
             .order_by(JlptGrammar.level.desc())
             .limit(limit)
         ).all()
-        return [dtos.JLPTGrammarDTO.from_orm(row) for row in rows]
+        return [dtos.JLPTGrammarDTO.model_validate(row) for row in rows]
 
     def kanji_by_literal(self, literal: str) -> dtos.JLPTKanjiDTO | None:
         """
         Fetch the JLPT kanji entry for a literal
 
+        Selects the first [`JlptKanji`][kotobase.db.models.JlptKanji] row whose
+        `kanji` equals `literal` exactly (`LIMIT 1`) and validates it into a
+        [`JLPTKanjiDTO`][kotobase.db.dtos.JLPTKanjiDTO]
+
         Args:
             literal (str): The kanji character
 
         Returns:
-            The JLPT kanji entry, or None when it is not listed
+            The JLPT kanji entry as a DTO, or `None` when it is not listed
         """
         row = self.session.scalars(
             select(JlptKanji).where(JlptKanji.kanji == literal).limit(1)
         ).first()
-        return dtos.JLPTKanjiDTO.from_orm(row) if row else None
+        return dtos.JLPTKanjiDTO.model_validate(row) if row else None
 
     def list_vocab(self, level: int) -> list[dtos.JLPTVocabDTO]:
         """
         Return the full vocabulary study list for a level
 
+        Selects every [`JlptVocab`][kotobase.db.models.JlptVocab] row whose
+        `level` equals `level`, ordered by ascending id (insertion order), and
+        validates each into a [`JLPTVocabDTO`][kotobase.db.dtos.JLPTVocabDTO]
+
         Args:
             level (int): The JLPT level from 1 to 5
 
         Returns:
-            Every vocabulary item at the level
+            Every vocabulary item at the level as DTOs, or `[]` when the level
+                is empty
         """
         rows = self.session.scalars(
             select(JlptVocab)
             .where(JlptVocab.level == level)
             .order_by(JlptVocab.id)
         ).all()
-        return [dtos.JLPTVocabDTO.from_orm(row) for row in rows]
+        return [dtos.JLPTVocabDTO.model_validate(row) for row in rows]
 
     def list_kanji(self, level: int) -> list[dtos.JLPTKanjiDTO]:
         """
         Return the full kanji study list for a level
 
+        Selects every [`JlptKanji`][kotobase.db.models.JlptKanji] row whose
+        `level` equals `level`, ordered by ascending id (insertion order), and
+        validates each into a [`JLPTKanjiDTO`][kotobase.db.dtos.JLPTKanjiDTO]
+
         Args:
             level (int): The JLPT level from 1 to 5
 
         Returns:
-            Every kanji item at the level
+            Every kanji item at the level as DTOs, or `[]` when the level is
+                empty
         """
         rows = self.session.scalars(
             select(JlptKanji)
             .where(JlptKanji.level == level)
             .order_by(JlptKanji.id)
         ).all()
-        return [dtos.JLPTKanjiDTO.from_orm(row) for row in rows]
+        return [dtos.JLPTKanjiDTO.model_validate(row) for row in rows]
 
     def list_grammar(self, level: int) -> list[dtos.JLPTGrammarDTO]:
         """
         Return the full grammar study list for a level
 
+        Selects every [`JlptGrammar`][kotobase.db.models.JlptGrammar] row whose
+        `level` equals `level`, ordered by ascending id (insertion order), then
+        validates each row into a
+        [`JLPTGrammarDTO`][kotobase.db.dtos.JLPTGrammarDTO]
+
         Args:
             level (int): The JLPT level from 1 to 5
 
         Returns:
-            Every grammar point at the level
+            Every grammar point at the level as DTOs, or `[]` when the level is
+                empty
         """
         rows = self.session.scalars(
             select(JlptGrammar)
             .where(JlptGrammar.level == level)
             .order_by(JlptGrammar.id)
         ).all()
-        return [dtos.JLPTGrammarDTO.from_orm(row) for row in rows]
+        return [dtos.JLPTGrammarDTO.model_validate(row) for row in rows]
 
 
 # --- Tags and audio ---
-class TagRepo(Repository):
+class TagRepo(KotobaseRepo):
     """
-    Queries the tag dictionary that expands codes to descriptions
+    Repository for the tag dictionary that expands codes to descriptions
     """
 
     def labels(self, codes: Sequence[str]) -> dict[str, str]:
         """
         Map tag codes to their human readable descriptions
 
+        De-duplicates `codes`, then selects `(code, description)` from
+        [`Tag`][kotobase.db.models.Tag] where `code` is `IN` that set. Because
+        the lookup is by `code` alone (not by category), a code shared across
+        tag families collapses to a single description. An empty input returns
+        `{}` without a query
+
         Args:
             codes (Sequence[str]): The tag codes to expand
 
         Returns:
-            A mapping of code to description for those that are known
+            A mapping of code to description for the codes that are known,
+                omitting any that are not in the tag table
         """
         wanted = list(dict.fromkeys(codes))
         if not wanted:
@@ -838,19 +1289,15 @@ class TagRepo(Repository):
         return {row.code: row.description for row in rows}
 
 
-_AUDIO_PACK_MISSING = (
-    "Couldn't Find The Audio Database. Run "
-    "`kotobase db pull --with-audio` Or "
-    "`kotobase db build --with-audio` To Get It"
-)
-"""
-Error message used when the optional audio pack is not attached
-"""
-
-
-class AudioRepo(Repository):
+class AudioRepo(KotobaseRepo):
     """
-    Queries pronunciation audio metadata and clips
+    Repository for pronunciation audio metadata and clip bytes
+
+    The `audio` table lives in the optional audio pack, attached to the
+    connection only when installed. When it is absent the underlying query
+    raises an `OperationalError`, which both methods translate into an
+    [`AudioDatabaseNotFoundError`][kotobase.exceptions.AudioDatabaseNotFoundError]
+    after rolling back the session
     """
 
     def for_key(
@@ -860,14 +1307,23 @@ class AudioRepo(Repository):
         kind: str | None = None,
     ) -> list[dtos.AudioDTO]:
         """
-        Fetch audio metadata for a lookup key
+        Fetch audio clip metadata for a lookup key
+
+        Selects [`Audio`][kotobase.db.models.Audio] rows whose `key` equals
+        `key` exactly, optionally narrowed to a single `kind`, and validates
+        each into an [`AudioDTO`][kotobase.db.dtos.AudioDTO], which carries
+        provenance and format metadata but not the raw `data` bytes. When the
+        audio pack is not attached the query raises `OperationalError`, which
+        is caught, the session is rolled back, and an
+        `AudioDatabaseNotFoundError` is raised instead
 
         Args:
             key (str): The lookup key, such as a kanji or word
             kind (str | None): Restrict to a clip kind when given
 
         Returns:
-            The matching audio clips as metadata, without the raw bytes
+            The matching audio clips as metadata DTOs without the raw bytes, or
+                `[]` when none match
 
         Raises:
             AudioDatabaseNotFoundError: If the optional audio pack is not
@@ -880,8 +1336,12 @@ class AudioRepo(Repository):
             rows = self.session.scalars(statement).all()
         except OperationalError:
             self.session.rollback()
-            raise AudioDatabaseNotFoundError(_AUDIO_PACK_MISSING) from None
-        return [dtos.AudioDTO.from_orm(row) for row in rows]
+            raise AudioDatabaseNotFoundError(
+                "Couldn't Find The Audio Database. Run "
+                "`kotobase db pull --with-audio` Or "
+                "`kotobase db build --with-audio` To Get It"
+            ) from None
+        return [dtos.AudioDTO.model_validate(row) for row in rows]
 
     def payloads(
         self,
@@ -893,13 +1353,23 @@ class AudioRepo(Repository):
         """
         Fetch the file name and raw bytes of each matching audio clip
 
+        Selects [`Audio`][kotobase.db.models.Audio] rows whose `key` equals
+        `key` exactly, optionally narrowed by exact `reading` and/or `kind`.
+        Rows whose `data` is `None` (metadata-only entries, such as remote
+        clips) are skipped. For the rest, a download file name is built as
+        `<reading or key>.<fmt or "mp3">` and paired with the raw bytes. When
+        the audio pack is not attached the query raises `OperationalError`,
+        which is caught, the session is rolled back, and an
+        `AudioDatabaseNotFoundError` is raised instead
+
         Args:
             key (str): The lookup key, such as a kanji or word
             reading (str | None): Restrict to a single clip reading when given
             kind (str | None): Restrict to a clip kind when given
 
         Returns:
-            A file name and bytes pair for every bundled clip that matches
+            A `(file name, bytes)` pair for every matching clip that has
+                bundled audio, or `[]` when none match or none carry bytes
 
         Raises:
             AudioDatabaseNotFoundError: If the optional audio pack is not
@@ -914,7 +1384,11 @@ class AudioRepo(Repository):
             rows = self.session.scalars(statement).all()
         except OperationalError:
             self.session.rollback()
-            raise AudioDatabaseNotFoundError(_AUDIO_PACK_MISSING) from None
+            raise AudioDatabaseNotFoundError(
+                "Couldn't Find The Audio Database. Run "
+                "`kotobase db pull --with-audio` Or "
+                "`kotobase db build --with-audio` To Get It"
+            ) from None
         result: list[tuple[str, bytes]] = []
         for row in rows:
             if row.data is None:

--- a/kotobase/src/kotobase/exceptions.py
+++ b/kotobase/src/kotobase/exceptions.py
@@ -1,0 +1,89 @@
+"""
+Defines kotobase's exception hierarchy
+"""
+
+# --- Package-Wide Base ---
+
+
+class KotobaseError(Exception):
+    """
+    Common base class for all exceptions raised by kotobase
+    """
+
+
+# --- Domain Bases ---
+
+
+class DatabaseError(KotobaseError):
+    """
+    Common base class for all exceptions resulting from database management
+    operations
+
+    These errors indicate that there has been a problem querying or building
+    the `SQLite` databases that kotobase relies on
+    """
+
+
+class SourceExtractionError(KotobaseError):
+    """
+    Common base class for all exceptions resulting from upstream source data
+    parsing
+
+    These errors indicate that an extractor couldn't produce valid database
+    rows from an upstream data source
+    """
+
+
+class DownloadError(KotobaseError):
+    """
+    Common base class for all exceptions resulting from network downloads
+
+    These errors indicate that the upstream data source files, or the pre-built
+    databases couldn't be fetched
+    """
+
+
+class APIError(KotobaseError):
+    """
+    Common base class for all exceptions coming directly from kotobase's
+    top-level [`API`][kotobase.api]
+
+    These errors indicate that the top-level
+    [`Kotobase`][kotobase.api.Kotobase] received invalid arguments or had
+    problems using the [`DTOs`][kotobase.db.dtos] produced by the
+    [`repos`][kotobase.db.repos]
+    """
+
+
+# --- Database Errors ---
+
+
+class DatabaseNotFoundError(DatabaseError):
+    """
+    Raised when a query to the core database is attempted before the database
+    exists
+    """
+
+
+class AudioDatabaseNotFoundError(DatabaseError):
+    """
+    Raised when audio bytes are requested, but the optional audio database pack
+    is not installed
+    """
+
+
+class DatabaseExistsError(DatabaseError):
+    """
+    Raised when a build or pull would overwrite a database that already exists
+    and the caller did not request a forced rebuild
+    """
+
+
+# --- Extraction Errors ---
+
+
+class MalformedSourceError(SourceExtractionError):
+    """
+    Raised when an upstream source does not follow the format expected by its
+    extractor, indicating that it might be malformed
+    """

--- a/kotobase/tests/conftest.py
+++ b/kotobase/tests/conftest.py
@@ -1,0 +1,193 @@
+"""
+Shared fixtures for the kotobase test suite
+
+A tiny `SQLite` database is built from the `ORM` models into a temporary
+cache directory, so the database-backed tests run anywhere, including in `CI`,
+without the real multi-hundred-megabyte database or any network access
+
+The `audio` table is dropped from the fixture to mirror the core database,
+where audio lives only in the optional pack, so the audio-missing error path
+is exercised faithfully
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import Session
+
+from kotobase import Kotobase
+from kotobase.db import connection, models
+from kotobase.db.builder import config
+
+
+def _populate(session: Session) -> None:
+    """
+    Insert a small, hand-picked set of rows covering the query paths
+
+    Args:
+        session (Session): A writable session into the fixture database
+    """
+    session.add_all(
+        [
+            models.JMDictEntry(
+                id=1,
+                is_common=True,
+                freq_rank=1,
+                kanji=[
+                    models.JMDictKanji(
+                        position=0,
+                        text="日本語",
+                        is_common=True,
+                        priority=["news1"],
+                    )
+                ],
+                kana=[
+                    models.JMDictKana(
+                        position=0, text="にほんご", is_common=True
+                    )
+                ],
+                senses=[
+                    models.JMDictSense(
+                        position=0,
+                        pos=["n"],
+                        xref=["英語"],
+                        glosses=[
+                            models.JMDictGloss(
+                                position=0,
+                                lang="eng",
+                                text="Japanese (language)",
+                            )
+                        ],
+                    )
+                ],
+            ),
+            models.JMDictEntry(
+                id=2,
+                is_common=True,
+                kanji=[models.JMDictKanji(position=0, text="英語")],
+                kana=[models.JMDictKana(position=0, text="えいご")],
+                senses=[
+                    models.JMDictSense(
+                        position=0,
+                        pos=["n"],
+                        glosses=[
+                            models.JMDictGloss(
+                                position=0,
+                                lang="eng",
+                                text="English (language)",
+                            )
+                        ],
+                    )
+                ],
+            ),
+            models.JMnedictEntry(
+                id=3,
+                kanji=[models.JMnedictKanji(position=0, text="田中")],
+                kana=[models.JMnedictKana(position=0, text="たなか")],
+                translations=[
+                    models.JMnedictTranslation(
+                        position=0,
+                        name_type=["surname"],
+                        glosses=[
+                            models.JMnedictGloss(position=0, text="Tanaka")
+                        ],
+                    )
+                ],
+            ),
+            models.Kanji(
+                literal="語",
+                grade=2,
+                stroke_count=14,
+                freq=301,
+                jlpt_old=4,
+                readings=[
+                    models.KanjiReading(type="ja_on", value="ゴ", position=0),
+                    models.KanjiReading(
+                        type="ja_kun", value="かた.る", position=1
+                    ),
+                ],
+                meanings=[
+                    models.KanjiMeaning(lang="en", value="word", position=0),
+                    models.KanjiMeaning(
+                        lang="en", value="language", position=1
+                    ),
+                ],
+                query_codes=[
+                    models.KanjiQueryCode(type="skip", value="1-7-7"),
+                    models.KanjiQueryCode(type="four_corner", value="0166.1"),
+                ],
+                dic_refs=[models.KanjiDicRef(type="nelson_c", value="4374")],
+                codepoints=[models.KanjiCodepoint(type="ucs", value="8a9e")],
+                strokes=models.KanjiStrokes(
+                    stroke_count=14, svg="<svg></svg>"
+                ),
+            ),
+            models.Kanji(literal="言", grade=2, stroke_count=7),
+            models.Kanji(literal="五", grade=1, stroke_count=4),
+            models.Radical(radical="言", stroke_count=7),
+            models.Radical(radical="五", stroke_count=4),
+            models.Radical(radical="口", stroke_count=3),
+            models.KanjiRadical(literal="語", radical="言"),
+            models.KanjiRadical(literal="語", radical="五"),
+            models.KanjiRadical(literal="語", radical="口"),
+            models.KanjiRadical(literal="言", radical="言"),
+            models.KanjiRadical(literal="五", radical="五"),
+            models.JlptKanji(level=5, kanji="語", on_yomi="ゴ"),
+            models.JlptVocab(level=5, word="日本語", reading="にほんご"),
+            models.Sentence(id=1, lang="jpn", text="日本語を勉強する。"),
+            models.Sentence(id=2, lang="eng", text="I study Japanese."),
+            models.SentenceLink(source_id=1, target_id=2),
+            models.Tag(code="n", category="pos", description="noun"),
+            models.Tag(code="sl", category="misc", description="slang"),
+            models.DbMeta(
+                key="schema_version", value=str(models.SCHEMA_VERSION)
+            ),
+        ]
+    )
+    session.commit()
+
+
+def _build_database() -> None:
+    """
+    Create and populate the fixture database in the active cache directory
+    """
+    config.ensure_dirs()
+    path = config.db_path()
+    engine = create_engine(f"sqlite:///{path}")
+    models.Base.metadata.create_all(engine)
+    # The core database has no `audio` table
+    with engine.begin() as conn:
+        conn.execute(text("DROP TABLE audio"))
+    with Session(engine) as session:
+        _populate(session)
+    engine.dispose()
+    # Drop the cached read-only engine so it reopens the populated file
+    connection.get_engine.cache_clear()
+    connection.get_sessionmaker.cache_clear()
+
+
+@pytest.fixture(scope="session")
+def kb(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Iterator[Kotobase]:
+    """
+    Yield a Kotobase backed by a freshly built, tiny fixture database
+
+    Yields:
+        A Kotobase instance pointed at the temporary fixture database
+    """
+    cache = tmp_path_factory.mktemp("kotobase_cache")
+    patch = pytest.MonkeyPatch()
+    patch.setenv(config.ENV_CACHE_DIR, str(cache))
+    connection.get_engine.cache_clear()
+    connection.get_sessionmaker.cache_clear()
+    _build_database()
+    try:
+        yield Kotobase()
+    finally:
+        connection.get_engine.cache_clear()
+        connection.get_sessionmaker.cache_clear()
+        patch.undo()

--- a/kotobase/tests/test_api.py
+++ b/kotobase/tests/test_api.py
@@ -1,0 +1,167 @@
+"""
+Database-backed tests for the public Kotobase API
+
+These run against the tiny fixture database from conftest
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kotobase import APIError, AudioDatabaseNotFoundError, Kotobase
+
+
+def test_lookup_aggregates_sources(kb: Kotobase) -> None:
+    """
+    A comprehensive lookup returns the entry and its kanji
+    """
+    result = kb.lookup("日本語")
+    assert result.has_entries()
+    assert result.entries[0].headword == "日本語"
+    assert result.has_kanji()
+    assert any(k.literal == "語" for k in result.kanji)
+
+
+def test_kanji_orm_mapping_derives_fields(kb: Kotobase) -> None:
+    """
+    KanjiDTO is assembled from several relationships and injected data
+    """
+    kanji = kb.kanji("語")
+    assert kanji is not None
+    assert kanji.onyomi == ["ゴ"]
+    assert kanji.kunyomi == ["かた.る"]
+    assert kanji.meanings == ["word", "language"]
+    assert kanji.query_codes["skip"] == ["1-7-7"]
+    assert kanji.dic_refs["nelson_c"] == "4374"
+    assert kanji.codepoints["ucs"] == "8a9e"
+    assert kanji.has_stroke_order is True
+    assert sorted(kanji.radicals) == ["五", "口", "言"]
+    assert kanji.jlpt_tanos == 5
+
+
+def test_serialization_keeps_japanese(kb: Kotobase) -> None:
+    """
+    A DTO built from the database serializes Japanese text verbatim
+    """
+    dumped = kb.lookup("日本語").model_dump_json()
+    assert "日本語" in dumped
+    assert "\\u" not in dumped
+
+
+def test_by_radicals_all_is_subset_of_any(kb: Kotobase) -> None:
+    """
+    `all` matches the intersection and `any` the union of radicals
+    """
+    every = kb.by_radicals(["言", "五"], match="all")
+    some = kb.by_radicals(["言", "五"], match="any")
+    assert [k.literal for k in every] == ["語"]
+    assert {k.literal for k in some} == {"語", "言", "五"}
+
+
+def test_by_radicals_accepts_radical_dtos(kb: Kotobase) -> None:
+    """
+    by_radicals reads the character off a RadicalDTO argument
+    """
+    radicals = {r.radical: r for r in kb.radicals()}
+    matched = kb.by_radicals([radicals["言"], radicals["五"]], match="all")
+    assert [k.literal for k in matched] == ["語"]
+
+
+def test_words_with_kanji(kb: Kotobase) -> None:
+    """
+    words_with_kanji finds entries whose written form contains a kanji
+    """
+    headwords = {entry.headword for entry in kb.words_with_kanji("語")}
+    assert headwords == {"日本語", "英語"}
+
+
+def test_words_with_kanji_accepts_dto(kb: Kotobase) -> None:
+    """
+    words_with_kanji reads the literal off a KanjiDTO argument
+    """
+    kanji = kb.kanji("語")
+    assert kanji is not None
+    assert kb.words_with_kanji(kanji)
+
+
+def test_sentences_with_kanji_aligns_translations(kb: Kotobase) -> None:
+    """
+    sentences_with_kanji returns matching sentences with their English
+    translation
+    """
+    sentences = kb.sentences_with_kanji("語")
+    assert sentences
+    assert "I study Japanese." in sentences[0].translations
+
+
+def test_resolve_references_follows_xref(kb: Kotobase) -> None:
+    """
+    resolve_references resolves an entry's xref code to its entry
+    """
+    entry = kb.lookup("日本語").entries[0]
+    resolved = kb.resolve_references(entry)
+    assert [entry.headword for entry in resolved] == ["英語"]
+
+
+def test_names_flattens_jmnedict_rows(kb: Kotobase) -> None:
+    """
+    A proper-name lookup flattens kanji, kana and gloss rows to strings
+    """
+    names = kb.names("田中")
+    assert names
+    assert names[0].kanji == ["田中"]
+    assert names[0].translations[0].translations == ["Tanaka"]
+
+
+def test_expand_tags(kb: Kotobase) -> None:
+    """
+    expand_tags maps tag codes to their descriptions
+    """
+    assert kb.expand_tags(["sl", "n"]) == {"sl": "slang", "n": "noun"}
+
+
+def test_jlpt_level(kb: Kotobase) -> None:
+    """
+    jlpt_level returns the vocabulary level of a listed word
+    """
+    assert kb.jlpt_level("日本語") == 5
+
+
+def test_audio_without_pack_raises(kb: Kotobase) -> None:
+    """
+    Requesting audio bytes without the pack raises the typed error
+    """
+    with pytest.raises(AudioDatabaseNotFoundError):
+        kb.audio_bytes("語")
+
+
+def test_jlpt_list_rejects_bad_arguments(kb: Kotobase) -> None:
+    """
+    jlpt_list rejects an unknown kind or out-of-range level
+    """
+    with pytest.raises(APIError):
+        kb.jlpt_list("bogus", 5)
+    with pytest.raises(APIError):
+        kb.jlpt_list("vocab", 9)
+
+
+def test_by_radicals_rejects_bad_match(kb: Kotobase) -> None:
+    """
+    by_radicals rejects a match mode other than all or any
+    """
+    with pytest.raises(APIError):
+        kb.by_radicals(["言"], match="nope")
+
+
+def test_methods_accept_dtos(kb: Kotobase) -> None:
+    """
+    Key-taking methods read the lookup key off a DTO argument
+    """
+    entry = kb.lookup("日本語").entries[0]
+    vocab = kb.jlpt_list("vocab", 5)[0]
+    kanji = kb.kanji("語")
+    assert kanji is not None
+    assert kb.jlpt_level(entry) == 5
+    assert kb.jlpt_level(vocab) == 5
+    assert kb.kanji(kanji) is not None
+    assert kb.sentences(entry)

--- a/kotobase/tests/test_cli.py
+++ b/kotobase/tests/test_cli.py
@@ -1,0 +1,70 @@
+"""
+Tests for the command-line interface
+
+Tests the database pull wiring, JSON output and the global error boundary that
+renders Kotobase errors as messages
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from kotobase import cli
+from kotobase.exceptions import DatabaseNotFoundError
+
+runner = CliRunner()
+
+
+def test_db_pull_pulls_audio_instead_of_building(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    `db pull` downloads the audio pack rather than rebuilding it
+    """
+    calls: list[str] = []
+    monkeypatch.setattr(
+        cli.builder, "pull_db", lambda **kw: calls.append("pull_db")
+    )
+    monkeypatch.setattr(
+        cli.builder, "pull_audio", lambda **kw: calls.append("pull_audio")
+    )
+    monkeypatch.setattr(
+        cli.builder, "build_audio", lambda **kw: calls.append("build_audio")
+    )
+    result = runner.invoke(cli.app, ["db", "pull"])
+    assert result.exit_code == 0
+    assert "pull_audio" in calls
+    assert "build_audio" not in calls
+
+
+def test_lookup_json_keeps_japanese_verbatim(kb: object) -> None:
+    """
+    The --json output is valid and keeps Japanese text unescaped
+    """
+    result = runner.invoke(cli.app, ["lookup", "all", "日本語", "-j"])
+    assert result.exit_code == 0
+    assert "日本語" in result.output
+    assert "\\u" not in result.output
+
+
+def test_main_renders_kotobase_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """
+    main() renders any KotobaseError and exits non-zero, no traceback
+    """
+
+    def boom() -> Any:
+        raise DatabaseNotFoundError("missing")
+
+    monkeypatch.setattr(cli, "app", boom)
+    monkeypatch.setattr(sys, "argv", ["kotobase"])
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main()
+    assert exc_info.value.code == 1
+    assert "Database" in capsys.readouterr().out

--- a/kotobase/tests/test_dtos.py
+++ b/kotobase/tests/test_dtos.py
@@ -1,0 +1,43 @@
+"""
+Tests for the pure, data-facing DTO methods that carry real logic
+
+Trivial accessors and the ORM-to-DTO mapping are covered through the API
+tests. These focus on the methods with branching or aggregation logic
+"""
+
+from __future__ import annotations
+
+from kotobase.db.dtos import JMDictEntryDTO, KanjiDTO, SenseDTO
+
+
+def test_all_pos_dedupes_and_preserves_order() -> None:
+    """
+    all_pos unions the senses' pos codes, keeping first-seen order
+    """
+    entry = JMDictEntryDTO.model_validate(
+        {
+            "id": 1,
+            "senses": [
+                {"pos": ["n", "vs"]},
+                {"pos": ["vs", "adj-na"]},
+            ],
+        }
+    )
+    assert entry.all_pos() == ["n", "vs", "adj-na"]
+
+
+def test_sense_expand_tags_falls_back_to_code() -> None:
+    """
+    expand_tags maps known codes and leaves unknown ones unchanged
+    """
+    sense = SenseDTO.model_validate({"pos": ["n"], "misc": ["sl"]})
+    assert sense.expand_tags({"n": "noun"}) == ["noun", "sl"]
+
+
+def test_kanji_is_joyo_boundary() -> None:
+    """
+    is_joyo is true for KanjiDic grades 1-8 and false beyond or absent
+    """
+    assert KanjiDTO.model_validate({"literal": "x", "grade": 8}).is_joyo()
+    assert not KanjiDTO.model_validate({"literal": "x", "grade": 9}).is_joyo()
+    assert not KanjiDTO.model_validate({"literal": "x"}).is_joyo()

--- a/kotobase/tests/test_exceptions.py
+++ b/kotobase/tests/test_exceptions.py
@@ -1,0 +1,71 @@
+"""
+Tests for the exception hierarchy, its top-level re-exports, and the
+repository-level wrapping of unexpected database failures
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+import kotobase
+from kotobase.db.repos import JMDictRepo
+from kotobase.exceptions import (
+    APIError,
+    AudioDatabaseNotFoundError,
+    DatabaseError,
+    DatabaseExistsError,
+    DatabaseNotFoundError,
+    DownloadError,
+    KotobaseError,
+    MalformedSourceError,
+    SourceExtractionError,
+)
+
+
+def test_domain_bases_descend_from_root() -> None:
+    """
+    The four domain bases can all be caught as KotobaseError
+    """
+    for exc in (DatabaseError, SourceExtractionError, DownloadError, APIError):
+        assert issubclass(exc, KotobaseError)
+
+
+def test_database_leaves_descend_from_database_error() -> None:
+    """
+    Every database leaf can be caught as a DatabaseError
+    """
+    for exc in (
+        DatabaseNotFoundError,
+        AudioDatabaseNotFoundError,
+        DatabaseExistsError,
+    ):
+        assert issubclass(exc, DatabaseError)
+
+
+def test_extraction_leaf_descends_from_extraction_error() -> None:
+    """
+    MalformedSourceError can be caught as a SourceExtractionError
+    """
+    assert issubclass(MalformedSourceError, SourceExtractionError)
+
+
+def test_exceptions_are_reexported_at_top_level() -> None:
+    """
+    The hierarchy is importable straight from the top-level package
+    """
+    assert kotobase.KotobaseError is KotobaseError
+    assert kotobase.APIError is APIError
+    assert kotobase.AudioDatabaseNotFoundError is AudioDatabaseNotFoundError
+
+
+def test_repo_wraps_unexpected_database_error() -> None:
+    """
+    A query against a schema-less database surfaces as a DatabaseError
+    """
+    engine = create_engine("sqlite:///:memory:")
+    with Session(engine) as session:
+        repo = JMDictRepo(session)
+        with pytest.raises(DatabaseError):
+            repo.search_form("語")


### PR DESCRIPTION
## Pydantic DTOs / Exception Hierarchy / Test Suite (v0.4.0)

A follow-up to the `0.3.0` rewrite that makes the data objects more useful, improves error handling and introduces an initial test suite

## Data Objects (`Pydantic`)

- DTOs migrate to `Pydantic v2` (`SafeORMModel`), built with `model_validate`
  directly from ORM rows. A `model_validator` replaces relationships that weren't
  eagerly loaded with `None` (no lazy loads), resolves field aliases, and
  overlays repo-injected values (a kanji's radicals / JLPT level, a sentence's translations) via the validation `context`. `KanjiDTO`'s derived fields are assembled in the repo

- DTOs gain pure, data-facing methods (`all_pos`, `common_kanji`,
  `all_tags`, `expand_tags`, `skip_codes`, `is_joyo`, `has_*`, …) and a `key`
  property (via a `Keyed` protocol), so a DTO can be handed to the API anywhere
  a string key is taken

- Serialization is now Pydantic's `model_dump` / `model_dump_json`. The
  Serializable` mixin and `to_dict` / `to_json` are removed.

## Exception Safety

- New `kotobase.exceptions` defines the exception hierarchy (`KotobaseError` &rarr; `DatabaseError`,
  `SourceExtractionError`, `DownloadError`, `APIError`), which are re-exported from the top-level package

- Repos wrap unexpected `SQLAlchemyError` as `DatabaseError` via
  `KotobaseRepo.__init_subclass__`

- The API raises `APIError` on invalid arguments

- The builder raises `DownloadError` / `SourceExtractionError` /
  `DatabaseExistsError` around network, parse and IO failures

- The CLI gains a global `main()` boundary that renders any `KotobaseError`
  as a friendly message and exits non-zero, replacing per-command `_guard_no_db`

## New Capabilities

- `by_radicals(..., match="any")` &rarr; Find kanji containing `any` of a set of
  radicals, alongside the existing `all`

- `resolve_references` &rarr;  (JMdict `xref` / `antonym`  &rarr; Entries)

- `words_with_kanji`

-  `sentences_with_kanji`

- Every key-taking method accepts `str | DTO`

- Every `limit` is now `int | None`, so capping results is always optional

## Fix

- `kotobase db pull` now downloads the prebuilt `kotobase-audio.db.zst`
  release asset instead of rebuilding the audio DB locally from the Kanji Alive
  sources

## Tests / CI / Docs

- A pytest suite runs against a tiny SQLite fixture built from the ORM
  models, covering the ORM &rarr; DTO mapping, pure DTO
  methods, exception typing, the pull fix, radical-ANY, reference resolution
  and the CLI boundary

- CI gains a test matrix (3.10–3.13) with Codecov (`codecov.yml`)

- `repos.py` docstrings are now more detailed

- New `exceptions` reference page

- `examples.md` rewritten as two task-oriented recipes (SRS deck, related-words)

- `pydantic>=2` added

- version bumped to **0.4.0**

- entry point changed to `kotobase.cli:main`.

## Breaking Changes

- `--json` output now follows Pydantic's `model_dump_json` (field names and
  Japanese text unchanged, but exact shape may differ)

- `to_dict` / `to_json` removed. Use `model_dump` / `model_dump_json`

- Invalid API arguments raise `APIError` instead of `ValueError`